### PR TITLE
feat(userscript): 支持 Public archive 仓库显示 DeepWiki 按钮

### DIFF
--- a/scripts/GitHubDeepWiki.user.js
+++ b/scripts/GitHubDeepWiki.user.js
@@ -60,7 +60,8 @@ function getRepoInfo() {
     }
 
     const visibilityText = visibilityLabel.textContent.trim().toLowerCase();
-    const isPublicRepo = visibilityText === 'public' || visibilityText === 'public archive';
+    const isPublicRepo =
+        visibilityText === 'public' || visibilityText === 'public archive';
     if (!isPublicRepo) {
         return null;
     }

--- a/scripts/GitHubDeepWiki.user.js
+++ b/scripts/GitHubDeepWiki.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @include      https://github.com/*/*
 // @icon         https://github.com/favicon.ico
-// @version      20251225
+// @version      20251229
 // @license      MIT
 // ==/UserScript==
 'use strict';
@@ -60,7 +60,8 @@ function getRepoInfo() {
     }
 
     const visibilityText = visibilityLabel.textContent.trim().toLowerCase();
-    if (visibilityText !== 'public') {
+    const isPublicRepo = visibilityText === 'public' || visibilityText === 'public archive';
+    if (!isPublicRepo) {
         return null;
     }
 


### PR DESCRIPTION
## Summary
- 支持 Public archive 仓库显示 DeepWiki 按钮，避免被误判为不可用。
- 同步更新脚本版本号。

## Key changes
- 放宽可见性判断为 public / public archive。
- 保持按钮插入逻辑不变。

## Testing
- 未测试（未进行手动验证）。
