### PR TITLE
feat(userscript): 添加 X/Twitter 图片滚轮翻页脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 
 | 脚本 | 简介 | 状态/链接 |
 | --- | --- | --- |
-| [豆瓣电影增强](scripts/MoviePlus.user.js) | 豆瓣电影页面右侧添加资源搜索入口 | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469243) |
-| [B 站视频后台标签页打开](scripts/BiliTab.user.js) | 劫持点击改为可后台新标签打开（支持开关/按键） | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469242) |
-| [Codex 用量窗口剩余时间](scripts/CodexUsageRemainingTime.user.js) | Codex 用量页面显示剩余时间 | 不发布到 GreasyFork |
-| [GitHub 仓库 DeepWiki 快捷入口](scripts/GitHubDeepWiki.user.js) | 仓库标题旁添加 DeepWiki 按钮 | 不发布到 GreasyFork |
-| [GitHub 日期数字化](scripts/GitHubDateNumeric.user.js) | GitHub 日期改为自定义数字/相对时间格式 | 不发布到 GreasyFork |
+| [MoviePlus.user.js](scripts/MoviePlus.user.js) | 豆瓣电影页面右侧添加资源搜索入口 | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469243) |
+| [BiliTab.user.js](scripts/BiliTab.user.js) | 劫持点击改为可后台新标签打开（支持开关/按键） | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469242) |
+| [CodexUsageRemainingTime.user.js](scripts/CodexUsageRemainingTime.user.js) | Codex 用量页面显示剩余时间 | 不发布到 GreasyFork |
+| [GitHubDeepWiki.user.js](scripts/GitHubDeepWiki.user.js) | 仓库标题旁添加 DeepWiki 按钮 | 不发布到 GreasyFork |
+| [GitHubDateNumeric.user.js](scripts/GitHubDateNumeric.user.js) | GitHub 日期改为自定义数字/相对时间格式 | 不发布到 GreasyFork |
+| [XTwitterImageWheel.user.js](scripts/XTwitterImageWheel.user.js) | X/Twitter 图片详情页滚轮翻页 | 不发布到 GreasyFork |
 
 MoviePlus Fork 自 [94leon/movie.plus](https://github.com/94leon/movie.plus)
 

--- a/scripts/XTwitterImageWheel.user.js
+++ b/scripts/XTwitterImageWheel.user.js
@@ -1,0 +1,70 @@
+// ==UserScript==
+// @name         XTwitterImageWheel
+// @name:zh-CN   X/Twitter 图片滚轮翻页
+// @namespace    https://github.com/dcjanus/userscripts
+// @description  在图片详情页用鼠标滚轮翻页
+// @author       DCjanus
+// @match        https://x.com/*
+// @match        https://twitter.com/*
+// @icon         https://abs.twimg.com/favicons/twitter.2.ico
+// @version      20260126
+// @license      MIT
+// @grant        none
+// ==/UserScript==
+'use strict';
+
+const SCRIPT_NAME = 'XTwitterImageWheel';
+const COOLDOWN_MS = 250;
+const CAROUSEL_SELECTOR =
+    'div[role="dialog"] [aria-roledescription="carousel"]';
+
+let lastTs = 0;
+
+function isInCarousel() {
+    return Boolean(document.querySelector(CAROUSEL_SELECTOR));
+}
+
+function dispatchArrow(key) {
+    const keyCode = key === 'ArrowLeft' ? 37 : 39;
+    const event = new KeyboardEvent('keydown', {
+        key,
+        code: key,
+        keyCode,
+        which: keyCode,
+        bubbles: true,
+        cancelable: true,
+    });
+    document.dispatchEvent(event);
+}
+
+function handleWheel(event) {
+    if (!isInCarousel()) {
+        return;
+    }
+
+    if (event.deltaY === 0) {
+        return;
+    }
+
+    const now = Date.now();
+    if (now - lastTs < COOLDOWN_MS) {
+        return;
+    }
+    lastTs = now;
+
+    if (event.deltaY < 0) {
+        dispatchArrow('ArrowLeft');
+    } else {
+        dispatchArrow('ArrowRight');
+    }
+}
+
+function setup() {
+    document.addEventListener('wheel', handleWheel, { passive: true });
+}
+
+try {
+    setup();
+} catch (error) {
+    console.error(`[${SCRIPT_NAME}]`, error);
+}


### PR DESCRIPTION
## Summary
新增 X/Twitter 图片详情页滚轮翻页脚本，并在 README 中补充条目。

## Key changes
- 新增 `XTwitterImageWheel` 脚本，监听滚轮触发左右翻页
- 加入冷却时间，避免滚轮触发过密
- README 脚本列表新增对应条目

## Constraints / tradeoffs
- 仅在图片轮播弹层存在时生效

## Testing
- 未测试（非交互式脚本，需在浏览器手动验证）
