### PR TITLE
fix(movieplus): 移除 jQuery 依赖

### DIFF
--- a/scripts/MoviePlus.user.js
+++ b/scripts/MoviePlus.user.js
@@ -8,7 +8,7 @@
 // @match          https://movie.douban.com/subject/*/?*
 // @exclude        https://movie.douban.com/subject/*/*/
 // @icon           https://raw.githubusercontent.com/DCjanus/userscripts/master/assets/douban.svg
-// @version        20260226
+// @version        20260504
 // @license        MIT
 // ==/UserScript==
 'use strict';
@@ -69,6 +69,9 @@ function parseURL(url) {
 
 function update_bt_site(title, year, douban_ID, IMDb_ID, title_cn) {
     let name, sites;
+    const siteList = document.querySelector('#content div.site-bt-body ul');
+    if (!siteList) return;
+
     title = title.trim();
     sites = {
         YIFY: 'https://yts.mx/browse-movies/' + title,
@@ -90,12 +93,15 @@ function update_bt_site(title, year, douban_ID, IMDb_ID, title_cn) {
 
     for (name in sites) {
         let link = parse_sites(name, sites);
-        $('#content div.site-bt-body ul').append(link);
+        siteList.append(link);
     }
 }
 
 function update_sub_site(title, douban_ID, IMDb_ID) {
     let name, sites;
+    const siteList = document.querySelector('#content div.site-sub-body ul');
+    if (!siteList) return;
+
     title = encodeURI(title);
 
     sites = {
@@ -106,20 +112,21 @@ function update_sub_site(title, douban_ID, IMDb_ID) {
 
     for (name in sites) {
         let link = parse_sites(name, sites);
-        $('#content div.site-sub-body ul').append(link);
+        siteList.append(link);
     }
 }
 
 function parse_sites(name, sites) {
     let link = sites[name],
         link_parsed = parseURL(link);
-    let aTag = $('<a></a>');
-    link = aTag.attr('href', link);
-    link.attr('data-host', link_parsed.host);
-    link.attr('target', '_blank').attr('rel', 'nofollow');
-    link.html(name);
+    const aTag = document.createElement('a');
+    aTag.href = link;
+    aTag.dataset.host = link_parsed.host;
+    aTag.target = '_blank';
+    aTag.rel = 'nofollow';
+    aTag.textContent = name;
 
-    return link;
+    return aTag;
 }
 
 function get_other_title_en(other_title) {
@@ -149,27 +156,49 @@ function format_series_name(name) {
     return name_arr[0] + 'S' + series_id;
 }
 
+function create_aside_section(title, sectionClass) {
+    const template = document.createElement('template');
+    template.innerHTML = aside_html.trim();
+
+    const section = template.content.firstElementChild;
+    section.classList.add(sectionClass);
+    section
+        .querySelector('div.c-aside-body')
+        .classList.add(sectionClass + '-body');
+    section.querySelector('h2 i').textContent = title;
+
+    return section;
+}
+
+function on_ready(callback) {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', callback, { once: true });
+        return;
+    }
+
+    callback();
+}
+
 function main() {
     const seBwhA = document.createElement('a');
     seBwhA.id = 'seBwhA';
     document.getElementsByTagName('html')[0].appendChild(seBwhA);
 
-    $(document).ready(() => {
-        let site_sub = $(aside_html),
-            selector = $('#content div.aside');
-        site_sub.addClass('name-offline');
-        site_sub.find('div.c-aside-body').addClass('site-sub-body');
-        site_sub.find('h2 i').text('字幕直达');
+    on_ready(() => {
+        const selector = document.querySelector('#content div.aside');
+        const h1_span = document.querySelectorAll('#content > h1 > span');
+        const info = document.querySelector('#info');
+        if (!selector || h1_span.length < 2 || !info) return;
+
+        let site_sub = create_aside_section('字幕直达', 'site-sub');
+        site_sub.classList.add('name-offline');
         selector.prepend(site_sub);
 
-        let site_bt = $(aside_html);
-        site_bt.addClass('site_bt');
-        site_bt.find('div.c-aside-body').addClass('site-bt-body');
-        site_bt.find('h2 i').text('BT 搜索');
+        let site_bt = create_aside_section('BT 搜索', 'site-bt');
+        site_bt.classList.add('site_bt');
         selector.prepend(site_bt);
 
-        let h1_span,
-            title_cn,
+        let title_cn,
             title_en,
             title_en_sub,
             bt_title,
@@ -177,7 +206,6 @@ function main() {
             douban_ID,
             IMDb_ID;
 
-        h1_span = $('#content > h1 > span');
         let title_all = h1_span[0].textContent;
 
         if (cn_total_reg.test(title_all)) {
@@ -231,7 +259,7 @@ function main() {
         }
 
         //解析info内容
-        let info_text = $('#info')[0].innerText,
+        let info_text = info.innerText,
             info_map = {};
         info_text.split('\n').forEach((line) => {
             let index = line.indexOf(':');


### PR DESCRIPTION
## 背景

- `MoviePlus.user.js` 在部分运行环境里无法拿到页面全局 `$`，会在豆瓣电影页面抛出 `ReferenceError: $ is not defined`。
- 这会阻断右侧快捷链接区块的渲染。

## 改动

- 将快捷链接区块创建、DOM 查询、链接追加逻辑改为原生 DOM API。
- 保留原有搜索链接生成逻辑，不再依赖页面或脚本管理器是否提供 jQuery。
- 按仓库规则更新 userscript `@version` 到 `20260504`。

## 验证

- `node --check scripts/MoviePlus.user.js`
- `git diff --check -- scripts/MoviePlus.user.js`

## 说明

- 豆瓣目标页面公开抓取会跳转安全校验页，因此本次未做真实页面截图验证。
