### PR TITLE
feat(codex): 优化每周用量窗口时间标记

### DIFF
--- a/scripts/CodexUsageRemainingTime.user.js
+++ b/scripts/CodexUsageRemainingTime.user.js
@@ -187,12 +187,13 @@ function updateWeeklySegments(progressHost) {
         for (let day = 1; day < WEEK_DAYS; day += 1) {
             const divider = document.createElement('span');
             divider.style.position = 'absolute';
-            divider.style.top = '-3px';
-            divider.style.bottom = '-3px';
+            divider.style.top = '-5px';
+            divider.style.bottom = '-5px';
             divider.style.left = `${(day / WEEK_DAYS) * 100}%`;
-            divider.style.width = '1px';
-            divider.style.transform = 'translateX(-0.5px)';
-            divider.style.backgroundColor = 'rgba(202, 138, 4, 0.28)';
+            divider.style.width = '2px';
+            divider.style.transform = 'translateX(-1px)';
+            divider.style.backgroundColor = 'rgba(202, 138, 4, 0.55)';
+            divider.style.boxShadow = '0 0 0 1px rgba(255, 255, 255, 0.7)';
             segments.appendChild(divider);
         }
         progressHost.appendChild(segments);
@@ -210,7 +211,12 @@ function getWeekDayIndex(resetDate, now) {
     return Math.max(0, Math.min(WEEK_DAYS - 1, rawIndex));
 }
 
-function updateWeeklyDayMarker(progressHost, resetDate, now) {
+function updateWeeklyDayMarker(
+    progressHost,
+    resetDate,
+    now,
+    timeRemainingPercent,
+) {
     updateWeeklySegments(progressHost);
 
     let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
@@ -221,7 +227,7 @@ function updateWeeklyDayMarker(progressHost, resetDate, now) {
     }
 
     const dayIndex = getWeekDayIndex(resetDate, now);
-    const left = `${((dayIndex + 0.5) / WEEK_DAYS) * 100}%`;
+    const left = `${clampPercent(timeRemainingPercent)}%`;
     const title = `每周窗口：当前第 ${dayIndex + 1} 天 / 共 ${WEEK_DAYS} 天`;
     setStyleValue(marker, 'position', 'absolute');
     setStyleValue(marker, 'top', 'calc(100% + 4px)');
@@ -229,12 +235,12 @@ function updateWeeklyDayMarker(progressHost, resetDate, now) {
     setStyleValue(marker, 'left', left);
     setStyleValue(marker, 'width', '0');
     setStyleValue(marker, 'height', '0');
-    setStyleValue(marker, 'borderLeft', '5px solid transparent');
-    setStyleValue(marker, 'borderRight', '5px solid transparent');
-    setStyleValue(marker, 'borderBottom', `7px solid ${MARKER_COLOR}`);
+    setStyleValue(marker, 'borderLeft', '6px solid transparent');
+    setStyleValue(marker, 'borderRight', '6px solid transparent');
+    setStyleValue(marker, 'borderBottom', `8px solid ${MARKER_COLOR}`);
     setStyleValue(marker, 'borderRadius', '');
     setStyleValue(marker, 'pointerEvents', 'none');
-    setStyleValue(marker, 'transform', 'translateX(-5px)');
+    setStyleValue(marker, 'transform', 'translateX(-6px)');
     setStyleValue(marker, 'backgroundColor', 'transparent');
     setStyleValue(marker, 'boxShadow', '');
     if (marker.title !== title) {
@@ -268,7 +274,12 @@ function updateArticle(article, now) {
     }
 
     if (windowMs === WINDOW_WEEK_MS) {
-        updateWeeklyDayMarker(progressHost, resetDate, now);
+        updateWeeklyDayMarker(
+            progressHost,
+            resetDate,
+            now,
+            timeRemainingPercent,
+        );
     } else {
         updateContinuousTimeMarker(progressHost, timeRemainingPercent);
     }

--- a/scripts/CodexUsageRemainingTime.user.js
+++ b/scripts/CodexUsageRemainingTime.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://chatgpt.com/codex/cloud/settings/analytics
 // @icon         https://chatgpt.com/cdn/assets/favicon-l4nq08hd.svg
-// @version      20260521
+// @version      20260521.1
 // @license      MIT
 // ==/UserScript==
 'use strict';
@@ -14,9 +14,12 @@
 const SCRIPT_NAME = 'CodexUsageRemainingTime';
 const RESET_PREFIX = '重置时间：';
 const TIME_MARKER_ATTR = 'data-codex-usage-time-marker';
+const WEEK_SEGMENTS_ATTR = 'data-codex-usage-week-segments';
+const MARKER_COLOR = 'rgb(202, 138, 4)';
 const UPDATE_INTERVAL_MS = 30 * 1000;
 const WINDOW_FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const WINDOW_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const WEEK_DAYS = 7;
 let updateScheduled = false;
 
 function normalizeText(text) {
@@ -139,30 +142,101 @@ function findProgressHost(article) {
     );
 }
 
-function updateTimeMarker(progressHost, timeRemainingPercent) {
+function setStyleValue(element, property, value) {
+    if (element.style[property] !== value) {
+        element.style[property] = value;
+    }
+}
+
+function updateContinuousTimeMarker(progressHost, timeRemainingPercent) {
     let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
     if (!marker) {
         marker = document.createElement('span');
         marker.setAttribute(TIME_MARKER_ATTR, 'true');
-        marker.style.position = 'absolute';
-        marker.style.top = '-3px';
-        marker.style.bottom = '-3px';
-        marker.style.width = '2px';
-        marker.style.borderRadius = '999px';
-        marker.style.pointerEvents = 'none';
-        marker.style.transform = 'translateX(-1px)';
-        marker.style.boxShadow = '0 0 0 1px rgba(255, 255, 255, 0.75)';
         progressHost.appendChild(marker);
     }
 
     const left = `${clampPercent(timeRemainingPercent)}%`;
     const title = `时间窗口剩余 ${Math.round(timeRemainingPercent)}%`;
-    if (marker.style.left !== left) {
-        marker.style.left = left;
+    setStyleValue(marker, 'position', 'absolute');
+    setStyleValue(marker, 'top', '-3px');
+    setStyleValue(marker, 'bottom', '-3px');
+    setStyleValue(marker, 'left', left);
+    setStyleValue(marker, 'width', '2px');
+    setStyleValue(marker, 'height', '');
+    setStyleValue(marker, 'borderLeft', '');
+    setStyleValue(marker, 'borderRight', '');
+    setStyleValue(marker, 'borderBottom', '');
+    setStyleValue(marker, 'borderRadius', '999px');
+    setStyleValue(marker, 'pointerEvents', 'none');
+    setStyleValue(marker, 'transform', 'translateX(-1px)');
+    setStyleValue(marker, 'backgroundColor', MARKER_COLOR);
+    setStyleValue(marker, 'boxShadow', '0 0 0 1px rgba(255, 255, 255, 0.75)');
+    if (marker.title !== title) {
+        marker.title = title;
     }
-    if (marker.style.backgroundColor !== 'rgb(202, 138, 4)') {
-        marker.style.backgroundColor = '#ca8a04';
+}
+
+function updateWeeklySegments(progressHost) {
+    let segments = progressHost.querySelector(
+        `span[${WEEK_SEGMENTS_ATTR}="true"]`,
+    );
+    if (!segments) {
+        segments = document.createElement('span');
+        segments.setAttribute(WEEK_SEGMENTS_ATTR, 'true');
+        for (let day = 1; day < WEEK_DAYS; day += 1) {
+            const divider = document.createElement('span');
+            divider.style.position = 'absolute';
+            divider.style.top = '-3px';
+            divider.style.bottom = '-3px';
+            divider.style.left = `${(day / WEEK_DAYS) * 100}%`;
+            divider.style.width = '1px';
+            divider.style.transform = 'translateX(-0.5px)';
+            divider.style.backgroundColor = 'rgba(202, 138, 4, 0.28)';
+            segments.appendChild(divider);
+        }
+        progressHost.appendChild(segments);
     }
+
+    setStyleValue(segments, 'position', 'absolute');
+    setStyleValue(segments, 'inset', '0');
+    setStyleValue(segments, 'pointerEvents', 'none');
+}
+
+function getWeekDayIndex(resetDate, now) {
+    const windowStartMs = resetDate.getTime() - WINDOW_WEEK_MS;
+    const elapsedMs = now.getTime() - windowStartMs;
+    const rawIndex = Math.floor((elapsedMs / WINDOW_WEEK_MS) * WEEK_DAYS);
+    return Math.max(0, Math.min(WEEK_DAYS - 1, rawIndex));
+}
+
+function updateWeeklyDayMarker(progressHost, resetDate, now) {
+    updateWeeklySegments(progressHost);
+
+    let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
+    if (!marker) {
+        marker = document.createElement('span');
+        marker.setAttribute(TIME_MARKER_ATTR, 'true');
+        progressHost.appendChild(marker);
+    }
+
+    const dayIndex = getWeekDayIndex(resetDate, now);
+    const left = `${((dayIndex + 0.5) / WEEK_DAYS) * 100}%`;
+    const title = `每周窗口：当前第 ${dayIndex + 1} 天 / 共 ${WEEK_DAYS} 天`;
+    setStyleValue(marker, 'position', 'absolute');
+    setStyleValue(marker, 'top', 'calc(100% + 4px)');
+    setStyleValue(marker, 'bottom', '');
+    setStyleValue(marker, 'left', left);
+    setStyleValue(marker, 'width', '0');
+    setStyleValue(marker, 'height', '0');
+    setStyleValue(marker, 'borderLeft', '5px solid transparent');
+    setStyleValue(marker, 'borderRight', '5px solid transparent');
+    setStyleValue(marker, 'borderBottom', `7px solid ${MARKER_COLOR}`);
+    setStyleValue(marker, 'borderRadius', '');
+    setStyleValue(marker, 'pointerEvents', 'none');
+    setStyleValue(marker, 'transform', 'translateX(-5px)');
+    setStyleValue(marker, 'backgroundColor', 'transparent');
+    setStyleValue(marker, 'boxShadow', '');
     if (marker.title !== title) {
         marker.title = title;
     }
@@ -189,8 +263,14 @@ function updateArticle(article, now) {
     const timeRemainingPercent = clampPercent((remainingMs / windowMs) * 100);
 
     const progressHost = findProgressHost(article);
-    if (progressHost) {
-        updateTimeMarker(progressHost, timeRemainingPercent);
+    if (!progressHost) {
+        return;
+    }
+
+    if (windowMs === WINDOW_WEEK_MS) {
+        updateWeeklyDayMarker(progressHost, resetDate, now);
+    } else {
+        updateContinuousTimeMarker(progressHost, timeRemainingPercent);
     }
 }
 

--- a/scripts/CodexUsageRemainingTime.user.js
+++ b/scripts/CodexUsageRemainingTime.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://chatgpt.com/codex/cloud/settings/analytics
 // @icon         https://chatgpt.com/cdn/assets/favicon-l4nq08hd.svg
-// @version      20260521.1
+// @version      20260521.2
 // @license      MIT
 // ==/UserScript==
 'use strict';
@@ -15,9 +15,9 @@ const SCRIPT_NAME = 'CodexUsageRemainingTime';
 const RESET_PREFIX = '重置时间：';
 const TIME_MARKER_ATTR = 'data-codex-usage-time-marker';
 const WEEK_SEGMENTS_ATTR = 'data-codex-usage-week-segments';
-const MARKER_COLOR = 'rgb(202, 138, 4)';
+const MARKER_COLOR = 'rgb(217, 119, 6)';
+const SEGMENT_COLOR = 'rgba(107, 114, 128, 0.42)';
 const UPDATE_INTERVAL_MS = 30 * 1000;
-const WINDOW_FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const WINDOW_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 const WEEK_DAYS = 7;
 let updateScheduled = false;
@@ -77,9 +77,6 @@ function clampPercent(value) {
 }
 
 function getWindowMs(title) {
-    if (title.includes('5') && title.includes('小时')) {
-        return WINDOW_FIVE_HOURS_MS;
-    }
     if (title.includes('每周')) {
         return WINDOW_WEEK_MS;
     }
@@ -148,35 +145,6 @@ function setStyleValue(element, property, value) {
     }
 }
 
-function updateContinuousTimeMarker(progressHost, timeRemainingPercent) {
-    let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
-    if (!marker) {
-        marker = document.createElement('span');
-        marker.setAttribute(TIME_MARKER_ATTR, 'true');
-        progressHost.appendChild(marker);
-    }
-
-    const left = `${clampPercent(timeRemainingPercent)}%`;
-    const title = `时间窗口剩余 ${Math.round(timeRemainingPercent)}%`;
-    setStyleValue(marker, 'position', 'absolute');
-    setStyleValue(marker, 'top', '-3px');
-    setStyleValue(marker, 'bottom', '-3px');
-    setStyleValue(marker, 'left', left);
-    setStyleValue(marker, 'width', '2px');
-    setStyleValue(marker, 'height', '');
-    setStyleValue(marker, 'borderLeft', '');
-    setStyleValue(marker, 'borderRight', '');
-    setStyleValue(marker, 'borderBottom', '');
-    setStyleValue(marker, 'borderRadius', '999px');
-    setStyleValue(marker, 'pointerEvents', 'none');
-    setStyleValue(marker, 'transform', 'translateX(-1px)');
-    setStyleValue(marker, 'backgroundColor', MARKER_COLOR);
-    setStyleValue(marker, 'boxShadow', '0 0 0 1px rgba(255, 255, 255, 0.75)');
-    if (marker.title !== title) {
-        marker.title = title;
-    }
-}
-
 function updateWeeklySegments(progressHost) {
     let segments = progressHost.querySelector(
         `span[${WEEK_SEGMENTS_ATTR}="true"]`,
@@ -187,13 +155,13 @@ function updateWeeklySegments(progressHost) {
         for (let day = 1; day < WEEK_DAYS; day += 1) {
             const divider = document.createElement('span');
             divider.style.position = 'absolute';
-            divider.style.top = '-5px';
-            divider.style.bottom = '-5px';
+            divider.style.top = '-3px';
+            divider.style.bottom = '-3px';
             divider.style.left = `${(day / WEEK_DAYS) * 100}%`;
-            divider.style.width = '2px';
+            divider.style.width = '1px';
             divider.style.transform = 'translateX(-1px)';
-            divider.style.backgroundColor = 'rgba(202, 138, 4, 0.55)';
-            divider.style.boxShadow = '0 0 0 1px rgba(255, 255, 255, 0.7)';
+            divider.style.backgroundColor = SEGMENT_COLOR;
+            divider.style.boxShadow = '0 0 0 1px rgba(255, 255, 255, 0.5)';
             segments.appendChild(divider);
         }
         progressHost.appendChild(segments);
@@ -230,19 +198,23 @@ function updateWeeklyDayMarker(
     const left = `${clampPercent(timeRemainingPercent)}%`;
     const title = `每周窗口：当前第 ${dayIndex + 1} 天 / 共 ${WEEK_DAYS} 天`;
     setStyleValue(marker, 'position', 'absolute');
-    setStyleValue(marker, 'top', 'calc(100% + 4px)');
+    setStyleValue(marker, 'top', 'calc(100% + 3px)');
     setStyleValue(marker, 'bottom', '');
     setStyleValue(marker, 'left', left);
-    setStyleValue(marker, 'width', '0');
-    setStyleValue(marker, 'height', '0');
-    setStyleValue(marker, 'borderLeft', '6px solid transparent');
-    setStyleValue(marker, 'borderRight', '6px solid transparent');
-    setStyleValue(marker, 'borderBottom', `8px solid ${MARKER_COLOR}`);
-    setStyleValue(marker, 'borderRadius', '');
+    setStyleValue(marker, 'width', '8px');
+    setStyleValue(marker, 'height', '8px');
+    setStyleValue(marker, 'borderLeft', '');
+    setStyleValue(marker, 'borderRight', '');
+    setStyleValue(marker, 'borderBottom', '');
+    setStyleValue(marker, 'borderRadius', '999px');
     setStyleValue(marker, 'pointerEvents', 'none');
-    setStyleValue(marker, 'transform', 'translateX(-6px)');
-    setStyleValue(marker, 'backgroundColor', 'transparent');
-    setStyleValue(marker, 'boxShadow', '');
+    setStyleValue(marker, 'transform', 'translateX(-4px)');
+    setStyleValue(marker, 'backgroundColor', MARKER_COLOR);
+    setStyleValue(
+        marker,
+        'boxShadow',
+        '0 0 0 2px rgba(255, 255, 255, 0.95), 0 1px 3px rgba(0, 0, 0, 0.18)',
+    );
     if (marker.title !== title) {
         marker.title = title;
     }
@@ -273,16 +245,7 @@ function updateArticle(article, now) {
         return;
     }
 
-    if (windowMs === WINDOW_WEEK_MS) {
-        updateWeeklyDayMarker(
-            progressHost,
-            resetDate,
-            now,
-            timeRemainingPercent,
-        );
-    } else {
-        updateContinuousTimeMarker(progressHost, timeRemainingPercent);
-    }
+    updateWeeklyDayMarker(progressHost, resetDate, now, timeRemainingPercent);
 }
 
 function updateAllCards() {

--- a/scripts/CodexUsageRemainingTime.user.js
+++ b/scripts/CodexUsageRemainingTime.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://chatgpt.com/codex/cloud/settings/analytics
 // @icon         https://chatgpt.com/cdn/assets/favicon-l4nq08hd.svg
-// @version      20260521.2
+// @version      20260521
 // @license      MIT
 // ==/UserScript==
 'use strict';


### PR DESCRIPTION
## 为什么

- 每周限额更适合按天观察使用节奏，单纯连续时间线不够直观。
- 5 小时限额不需要额外时间标记，保留原生剩余额度展示即可。

## 改了什么

- 每周限额进度条增加 7 等分的天级参考线。
- 每周限额使用底部黄色圆点表示当前时间位置，按剩余时间百分比连续移动，保留 hover 查看当前第几天。
- 移除 5 小时限额卡片上的额外时间标记。

## 验证

- `node --check scripts/CodexUsageRemainingTime.user.js`
- `npx prettier --check scripts/CodexUsageRemainingTime.user.js`
- `git diff --check`
