### PR TITLE
fix: 实时刷新 GitHub PR 文件树审阅状态

### DIFF
--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -7,7 +7,7 @@
 // @include      https://github.com/*/*/pull/*/files*
 // @include      https://github.com/*/*/pull/*/changes*
 // @icon         https://github.com/favicon.ico
-// @version      20260522
+// @version      2026052201
 // @license      MIT
 // @grant        none
 // ==/UserScript==
@@ -19,6 +19,7 @@ const STATS_CLASS = 'rgh-pr-file-tree-review-stats';
 const PATCHED_ATTR = 'data-rgh-pr-file-tree-review-stats';
 const VIEWED_ATTR = 'data-rgh-pr-file-viewed';
 const UPDATE_DELAY_MS = 100;
+const UPDATE_BURST_DELAYS_MS = [100, 300, 800, 1500, 3000];
 let updateTimer = 0;
 
 function isPrFilesPage() {
@@ -35,11 +36,13 @@ function ensureStyle() {
     const style = document.createElement('style');
     style.id = STYLE_ID;
     style.textContent = `
-        li[${VIEWED_ATTR}="false"] a[href^="#diff-"] {
+        li[${VIEWED_ATTR}="false"] a[href^="#diff-"],
+        a[${VIEWED_ATTR}="false"][href^="#diff-"] {
             font-weight: 600;
         }
 
-        li[${VIEWED_ATTR}="true"] a[href^="#diff-"] {
+        li[${VIEWED_ATTR}="true"] a[href^="#diff-"],
+        a[${VIEWED_ATTR}="true"][href^="#diff-"] {
             font-weight: 400;
         }
 
@@ -171,7 +174,10 @@ function collectFileTreeRows() {
 
     for (const link of document.querySelectorAll('a[href^="#diff-"]')) {
         const href = link.getAttribute('href');
-        const row = link.closest('li[class*="file-tree-row"]');
+        const row =
+            link.closest('li[class*="file-tree-row"]') ||
+            link.closest('li.ActionListItem') ||
+            (link.matches('.ActionList-content') ? link : null);
         if (!href || !row) {
             continue;
         }
@@ -183,6 +189,10 @@ function collectFileTreeRows() {
 }
 
 function getStatsHost(row, link) {
+    if (row === link) {
+        return link;
+    }
+
     return (
         row.querySelector('[class*="TreeViewItemContent"]') ||
         link.closest('[class*="TreeViewItemContentText"]') ||
@@ -253,15 +263,29 @@ function scheduleUpdate() {
     updateTimer = window.setTimeout(updateFileTree, UPDATE_DELAY_MS);
 }
 
+function scheduleUpdateBurst() {
+    for (const delay of UPDATE_BURST_DELAYS_MS) {
+        window.setTimeout(updateFileTree, delay);
+    }
+}
+
 function start() {
     scheduleUpdate();
 
     const observer = new MutationObserver(scheduleUpdate);
     observer.observe(document.body, {
         childList: true,
+        characterData: true,
         subtree: true,
         attributes: true,
-        attributeFilter: ['aria-pressed', 'aria-label', 'checked'],
+        attributeFilter: [
+            'aria-label',
+            'aria-pressed',
+            'checked',
+            'class',
+            'data-file-user-viewed',
+            'hidden',
+        ],
     });
 
     document.addEventListener(
@@ -276,15 +300,30 @@ function start() {
                     'button[class*="MarkAsViewedButton"], input.js-reviewed-checkbox',
                 )
             ) {
-                scheduleUpdate();
+                scheduleUpdateBurst();
             }
         },
         true,
     );
 
-    document.addEventListener('turbo:load', scheduleUpdate);
-    document.addEventListener('pjax:end', scheduleUpdate);
-    window.addEventListener('popstate', scheduleUpdate);
+    document.addEventListener(
+        'change',
+        (event) => {
+            if (
+                event.target instanceof Element &&
+                event.target.matches('input.js-reviewed-checkbox')
+            ) {
+                scheduleUpdateBurst();
+            }
+        },
+        true,
+    );
+
+    document.addEventListener('turbo:load', scheduleUpdateBurst);
+    document.addEventListener('turbo:render', scheduleUpdateBurst);
+    document.addEventListener('pjax:end', scheduleUpdateBurst);
+    window.addEventListener('focus', scheduleUpdateBurst);
+    window.addEventListener('popstate', scheduleUpdateBurst);
 }
 
 if (document.readyState === 'loading') {

--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -7,7 +7,7 @@
 // @include      https://github.com/*/*/pull/*/files*
 // @include      https://github.com/*/*/pull/*/changes*
 // @icon         https://github.com/favicon.ico
-// @version      2026052201
+// @version      20260522
 // @license      MIT
 // @grant        none
 // ==/UserScript==

--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -19,9 +19,7 @@ const STYLE_ID = 'rgh-pr-file-tree-review-stats-style';
 const STATS_CLASS = 'rgh-pr-file-tree-review-stats';
 const PATCHED_ATTR = 'data-rgh-pr-file-tree-review-stats';
 const VIEWED_ATTR = 'data-rgh-pr-file-viewed';
-const NETWORK_HOOKED = Symbol.for(
-    'GitHubPrFileTreeReviewStats.networkHooked',
-);
+const NETWORK_HOOKED = Symbol.for('GitHubPrFileTreeReviewStats.networkHooked');
 
 const FILE_SELECTOR =
     '[id^="diff-"].js-file, [id^="diff-"][class*="Diff-module__diffTargetable"]';
@@ -373,7 +371,9 @@ function installNetworkHooks() {
     }
 
     const nativeSend = XMLHttpRequest.prototype.send;
-    XMLHttpRequest.prototype.send = function sendWithReviewStatsUpdate(...args) {
+    XMLHttpRequest.prototype.send = function sendWithReviewStatsUpdate(
+        ...args
+    ) {
         this.addEventListener('loadend', schedulePostNetworkUpdate, {
             once: true,
         });

--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -10,6 +10,7 @@
 // @version      20260522
 // @license      MIT
 // @grant        none
+// @run-at       document-start
 // ==/UserScript==
 'use strict';
 
@@ -18,9 +19,20 @@ const STYLE_ID = 'rgh-pr-file-tree-review-stats-style';
 const STATS_CLASS = 'rgh-pr-file-tree-review-stats';
 const PATCHED_ATTR = 'data-rgh-pr-file-tree-review-stats';
 const VIEWED_ATTR = 'data-rgh-pr-file-viewed';
-const UPDATE_DELAY_MS = 100;
-const UPDATE_BURST_DELAYS_MS = [100, 300, 800, 1500, 3000];
-let updateTimer = 0;
+const NETWORK_HOOKED = Symbol.for(
+    'GitHubPrFileTreeReviewStats.networkHooked',
+);
+
+const FILE_SELECTOR =
+    '[id^="diff-"].js-file, [id^="diff-"][class*="Diff-module__diffTargetable"]';
+const FILE_HEADER_SELECTOR =
+    '.file-header, [class*="DiffHeader"], [class*="FileHeader"]';
+const VIEWED_CONTROL_SELECTOR =
+    'button[class*="MarkAsViewedButton"], input.js-reviewed-checkbox';
+const FILE_TREE_LINK_SELECTOR = 'a[href^="#diff-"]';
+
+let updateScheduled = false;
+let observerStarted = false;
 
 function isPrFilesPage() {
     return /^\/[^/]+\/[^/]+\/pull\/\d+\/(files|changes)/.test(
@@ -98,10 +110,7 @@ function parseLineStats(text) {
 }
 
 function getFileStats(file) {
-    const header =
-        file.querySelector('.file-header') ||
-        file.querySelector('[class*="DiffHeader"]') ||
-        file.querySelector('[class*="FileHeader"]');
+    const header = file.querySelector(FILE_HEADER_SELECTOR);
     if (!header) {
         return null;
     }
@@ -148,41 +157,28 @@ function getViewedState(file) {
     return null;
 }
 
-function collectDiffInfo() {
-    const infoByHash = new Map();
-    const files = document.querySelectorAll(
-        '[id^="diff-"].js-file, [id^="diff-"][class*="Diff-module__diffTargetable"]',
+function getHashFromLink(link) {
+    const href = link.getAttribute('href');
+    return href?.startsWith('#diff-') ? href.slice(1) : null;
+}
+
+function getFileTreeRow(link) {
+    return (
+        link.closest('li[class*="file-tree-row"]') ||
+        link.closest('li.ActionListItem') ||
+        (link.matches('.ActionList-content') ? link : null)
     );
-
-    for (const file of files) {
-        const stats = getFileStats(file);
-        if (!stats) {
-            continue;
-        }
-
-        infoByHash.set(file.id, {
-            ...stats,
-            viewed: getViewedState(file),
-        });
-    }
-
-    return infoByHash;
 }
 
 function collectFileTreeRows() {
     const rowsByHash = new Map();
 
-    for (const link of document.querySelectorAll('a[href^="#diff-"]')) {
-        const href = link.getAttribute('href');
-        const row =
-            link.closest('li[class*="file-tree-row"]') ||
-            link.closest('li.ActionListItem') ||
-            (link.matches('.ActionList-content') ? link : null);
-        if (!href || !row) {
-            continue;
+    for (const link of document.querySelectorAll(FILE_TREE_LINK_SELECTOR)) {
+        const hash = getHashFromLink(link);
+        const row = getFileTreeRow(link);
+        if (hash && row) {
+            rowsByHash.set(hash, { row, link });
         }
-
-        rowsByHash.set(href.slice(1), { row, link });
     }
 
     return rowsByHash;
@@ -195,23 +191,45 @@ function getStatsHost(row, link) {
 
     return (
         row.querySelector('[class*="TreeViewItemContent"]') ||
+        row.querySelector('.ActionList-content') ||
         link.closest('[class*="TreeViewItemContentText"]') ||
         link.parentElement
     );
 }
 
+function setAttributeValue(element, name, value) {
+    if (value === null) {
+        if (element.hasAttribute(name)) {
+            element.removeAttribute(name);
+        }
+        return;
+    }
+
+    const stringValue = String(value);
+    if (element.getAttribute(name) !== stringValue) {
+        element.setAttribute(name, stringValue);
+    }
+}
+
 function renderStatsElement(stats) {
     const element = document.createElement('span');
+    const added = document.createElement('span');
+    const deleted = document.createElement('span');
+
     element.className = STATS_CLASS;
     element.setAttribute(
         'aria-label',
         `${stats.additions} additions, ${stats.deletions} deletions`,
     );
     element.title = `${stats.additions} additions, ${stats.deletions} deletions`;
-    element.innerHTML = `
-        <span class="${STATS_CLASS}__added">+${stats.additions}</span>
-        <span class="${STATS_CLASS}__deleted">-${stats.deletions}</span>
-    `;
+
+    added.className = `${STATS_CLASS}__added`;
+    added.textContent = `+${stats.additions}`;
+
+    deleted.className = `${STATS_CLASS}__deleted`;
+    deleted.textContent = `-${stats.deletions}`;
+
+    element.append(added, deleted);
     return element;
 }
 
@@ -222,16 +240,24 @@ function updateRow(rowInfo, stats) {
         return;
     }
 
-    row.setAttribute(PATCHED_ATTR, 'true');
-    if (stats.viewed === null) {
-        row.removeAttribute(VIEWED_ATTR);
-    } else {
-        row.setAttribute(VIEWED_ATTR, String(stats.viewed));
+    setAttributeValue(row, PATCHED_ATTR, true);
+    setAttributeValue(
+        row,
+        VIEWED_ATTR,
+        typeof stats.viewed === 'boolean' ? stats.viewed : null,
+    );
+
+    if (row === link) {
+        setAttributeValue(
+            link,
+            VIEWED_ATTR,
+            typeof stats.viewed === 'boolean' ? stats.viewed : null,
+        );
     }
 
     const existing = host.querySelector(`.${STATS_CLASS}`);
+    const expected = `+${stats.additions}-${stats.deletions}`;
     if (existing) {
-        const expected = `+${stats.additions}-${stats.deletions}`;
         if (existing.textContent.replace(/\s+/g, '') !== expected) {
             existing.replaceWith(renderStatsElement(stats));
         }
@@ -241,39 +267,131 @@ function updateRow(rowInfo, stats) {
     host.appendChild(renderStatsElement(stats));
 }
 
+function updateFile(file, rowsByHash = collectFileTreeRows(), viewedOverride) {
+    const stats = getFileStats(file);
+    if (!stats) {
+        return;
+    }
+
+    const rowInfo = rowsByHash.get(file.id);
+    if (!rowInfo) {
+        return;
+    }
+
+    updateRow(rowInfo, {
+        ...stats,
+        viewed:
+            typeof viewedOverride === 'boolean'
+                ? viewedOverride
+                : getViewedState(file),
+    });
+}
+
 function updateFileTree() {
-    if (!isPrFilesPage()) {
+    updateScheduled = false;
+    if (!isPrFilesPage() || !document.body) {
         return;
     }
 
     ensureStyle();
-    const diffInfo = collectDiffInfo();
-    const fileTreeRows = collectFileTreeRows();
-
-    for (const [hash, rowInfo] of fileTreeRows) {
-        const stats = diffInfo.get(hash);
-        if (stats) {
-            updateRow(rowInfo, stats);
-        }
+    const rowsByHash = collectFileTreeRows();
+    for (const file of document.querySelectorAll(FILE_SELECTOR)) {
+        updateFile(file, rowsByHash);
     }
 }
 
 function scheduleUpdate() {
-    window.clearTimeout(updateTimer);
-    updateTimer = window.setTimeout(updateFileTree, UPDATE_DELAY_MS);
+    if (updateScheduled) {
+        return;
+    }
+
+    updateScheduled = true;
+    requestAnimationFrame(updateFileTree);
 }
 
-function scheduleUpdateBurst() {
-    for (const delay of UPDATE_BURST_DELAYS_MS) {
-        window.setTimeout(updateFileTree, delay);
+function schedulePostNetworkUpdate() {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(scheduleUpdate);
+    });
+}
+
+function getFileFromControl(control) {
+    return control.closest(FILE_SELECTOR);
+}
+
+function handleViewedClick(event) {
+    if (!(event.target instanceof Element)) {
+        return;
+    }
+
+    const control = event.target.closest(VIEWED_CONTROL_SELECTOR);
+    if (!control || control instanceof HTMLInputElement) {
+        return;
+    }
+
+    const file = getFileFromControl(control);
+    if (!file) {
+        return;
+    }
+
+    const currentViewed = getViewedState(file);
+    if (typeof currentViewed === 'boolean') {
+        updateFile(file, collectFileTreeRows(), !currentViewed);
     }
 }
 
+function handleViewedChange(event) {
+    if (
+        event.target instanceof HTMLInputElement &&
+        event.target.matches('input.js-reviewed-checkbox')
+    ) {
+        const file = getFileFromControl(event.target);
+        if (file) {
+            updateFile(file);
+        }
+    }
+}
+
+function installNetworkHooks() {
+    if (window[NETWORK_HOOKED]) {
+        return;
+    }
+
+    Object.defineProperty(window, NETWORK_HOOKED, {
+        value: true,
+    });
+
+    const nativeFetch = window.fetch;
+    if (typeof nativeFetch === 'function') {
+        window.fetch = async function fetchWithReviewStatsUpdate(...args) {
+            try {
+                return await nativeFetch.apply(this, args);
+            } finally {
+                schedulePostNetworkUpdate();
+            }
+        };
+    }
+
+    const nativeSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.send = function sendWithReviewStatsUpdate(...args) {
+        this.addEventListener('loadend', schedulePostNetworkUpdate, {
+            once: true,
+        });
+        return nativeSend.apply(this, args);
+    };
+}
+
 function start() {
+    if (observerStarted) {
+        return;
+    }
+    observerStarted = true;
+
+    installNetworkHooks();
     scheduleUpdate();
 
     const observer = new MutationObserver(scheduleUpdate);
-    observer.observe(document.body, {
+    observer.observe(document.documentElement, {
         childList: true,
         characterData: true,
         subtree: true,
@@ -288,48 +406,15 @@ function start() {
         ],
     });
 
-    document.addEventListener(
-        'click',
-        (event) => {
-            if (!(event.target instanceof Element)) {
-                return;
-            }
+    document.addEventListener('click', handleViewedClick, true);
+    document.addEventListener('change', handleViewedChange, true);
 
-            if (
-                event.target.closest(
-                    'button[class*="MarkAsViewedButton"], input.js-reviewed-checkbox',
-                )
-            ) {
-                scheduleUpdateBurst();
-            }
-        },
-        true,
-    );
-
-    document.addEventListener(
-        'change',
-        (event) => {
-            if (
-                event.target instanceof Element &&
-                event.target.matches('input.js-reviewed-checkbox')
-            ) {
-                scheduleUpdateBurst();
-            }
-        },
-        true,
-    );
-
-    document.addEventListener('turbo:load', scheduleUpdateBurst);
-    document.addEventListener('turbo:render', scheduleUpdateBurst);
-    document.addEventListener('pjax:end', scheduleUpdateBurst);
-    window.addEventListener('focus', scheduleUpdateBurst);
-    window.addEventListener('popstate', scheduleUpdateBurst);
+    document.addEventListener('turbo:load', scheduleUpdate);
+    document.addEventListener('turbo:render', scheduleUpdate);
+    document.addEventListener('pjax:end', scheduleUpdate);
+    window.addEventListener('popstate', scheduleUpdate);
 }
 
-if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', start, { once: true });
-} else {
-    start();
-}
+start();
 
 console.debug(`[${SCRIPT_NAME}] loaded`);


### PR DESCRIPTION
## Why

- Viewed 按钮保存是异步的，点击后文件树状态需要在不刷新页面的情况下重新同步。
- GitHub PR 的局部刷新可能只更新 diff header 文本或重挂载部分 DOM，文件树里的增删行数也需要跟着更新。

## What

- 改成事件驱动同步：DOM mutation、Viewed 控件事件、GitHub 自身 `fetch` / `XMLHttpRequest` 完成后都会触发同步。
- Viewed 点击时只对当前文件做乐观同步，后续由 DOM/network 事件回读页面真实状态校正。
- 新增 `@run-at document-start`，尽早安装网络完成 hook，覆盖 PR Files 的局部刷新和新 commit 更新。
- 保持 userscript version 不变，不用版本号承载这个 draft PR 的内部迭代。
- 兼容旧版 GitHub file tree 中没有 `file-tree-row` li 的链接结构。

## Validation

- `node --check scripts/GitHubPrFileTreeReviewStats.user.js`
- `git diff --check`
- 使用本机 Chrome headless 加载 `refined-github/refined-github#9486`，注入脚本后确认 3 个文件统计可显示。
- 模拟 diff header 文本变化后触发页面 fetch 完成信号，文件树统计从原始值更新到 `+2-0`。
