### PR TITLE
chore(userscripts): 审查并替换 include 元数据

### DIFF
--- a/scripts/GitHubDeepWiki.user.js
+++ b/scripts/GitHubDeepWiki.user.js
@@ -4,10 +4,10 @@
 // @namespace    https://github.com/dcjanus/userscripts
 // @description  在 GitHub 仓库标题旁增加 DeepWiki 按钮，并在 DeepWiki 页面展示上次索引时间
 // @author       DCjanus
-// @include      https://github.com/*/*
-// @include      https://deepwiki.com/*
+// @match        https://github.com/*/*
+// @match        https://deepwiki.com/*
 // @icon         https://raw.githubusercontent.com/DCjanus/userscripts/master/assets/deepwiki.svg
-// @version      20260109
+// @version      20260531
 // @license      MIT
 // ==/UserScript==
 'use strict';


### PR DESCRIPTION
## 为什么

- 仓库已明确 userscript 匹配规则偏好：同样能满足功能时优先使用 `@match`。
- 现有脚本中仍有少量 `@include`，需要统一审查并收敛到更标准的匹配元数据。

## 改了什么

- 审查所有 userscript 元数据中的 `@include`。
- 将 `GitHubDeepWiki.user.js` 的 GitHub 和 DeepWiki 匹配规则从 `@include` 改为等价的 `@match`。
- 按仓库规则更新 `GitHubDeepWiki.user.js` 版本号到 `20260531`。

## 验证

- `rg -n '^//\\s*@include\\s+' scripts/*.user.js` 未找到剩余 `@include`
- `node --check scripts/GitHubDeepWiki.user.js`
