### PR TITLE
fix(github-pr-file-tree): 修复新增文件未加粗

### DIFF
--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://github.com/*
 // @icon         https://github.com/favicon.ico
-// @version      20260531
+// @version      20260601
 // @license      MIT
 // @grant        none
 // @run-at       document-start
@@ -124,7 +124,33 @@ function getFileStats(file) {
     return parseLineStats(statText);
 }
 
+function parseBooleanAttribute(value) {
+    if (value === null) {
+        return null;
+    }
+
+    if (/^(true|1)$/i.test(value)) {
+        return true;
+    }
+    if (/^(false|0)$/i.test(value)) {
+        return false;
+    }
+
+    return null;
+}
+
 function getViewedState(file) {
+    const dataViewed = parseBooleanAttribute(
+        file.getAttribute('data-file-user-viewed') ||
+            file
+                .querySelector('[data-file-user-viewed]')
+                ?.getAttribute('data-file-user-viewed') ||
+            null,
+    );
+    if (typeof dataViewed === 'boolean') {
+        return dataViewed;
+    }
+
     const input = file.querySelector('input.js-reviewed-checkbox');
     if (input) {
         return input.checked;
@@ -134,7 +160,7 @@ function getViewedState(file) {
         'button[class*="MarkAsViewedButton"], button[aria-pressed][aria-label*="Viewed"], button[aria-pressed][aria-label*="viewed"]',
     );
     if (!button) {
-        return null;
+        return false;
     }
 
     const pressed = button.getAttribute('aria-pressed');
@@ -153,7 +179,7 @@ function getViewedState(file) {
         return true;
     }
 
-    return null;
+    return false;
 }
 
 function getHashFromLink(link) {


### PR DESCRIPTION
## Why

- GitHub PR changes 页里，部分完全新增的大文件不会渲染 Viewed 按钮或 `data-file-user-viewed` 属性。
- 原脚本把这种状态当成 unknown，导致文件树中未标记 viewed 的新增文件没有加粗。

## What

- 解析 `data-file-user-viewed` 作为 viewed 状态的额外来源。
- 当无法从 GitHub DOM 读取到明确 viewed 信号时，默认按未 viewed 处理。
- 更新 `GitHubPrFileTreeReviewStats` userscript 版本号到 `20260601`。

## Validation

- `node --check scripts/GitHubPrFileTreeReviewStats.user.js`
- `pnpx prettier --check scripts/GitHubPrFileTreeReviewStats.user.js`
- 在真实 GitHub PR changes 页刷新验证：
  - 完全新增且未 viewed 的 `backend.rs` / `config.rs` 文件树行变为 `data-rgh-pr-file-viewed="false"`，字重为 `600`。
  - 已 viewed 文件仍保持 `data-rgh-pr-file-viewed="true"`，字重为 `400`。
