### PR TITLE
chore: 迁移到 prek 和 Biome 检查

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,18 +7,15 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  prettier:
+  prek:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
 
-      - name: Prettify code
-        uses: creyD/prettier_action@v4.6
+      - name: Run prek
+        uses: j178/prek-action@v2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-LICENSE

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,0 @@
-{
-  "trailingComma": "all",
-  "tabWidth": 4,
-  "semi": true,
-  "singleQuote": true
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,7 @@
 
 ## Userscript 匹配规则
 - 在 `@match` 和 `@include` 都能满足功能的情况下，优先使用 `@match`。
+
+## 提交前检查
+- 本仓库使用 `prek` 管理提交前 hook。
+- clone 后应运行 `prek install` 安装本地 hook。

--- a/README.md
+++ b/README.md
@@ -8,20 +8,28 @@
 
 # 脚本列表
 
-| 脚本                                                                       | 简介                                            | 状态/链接                                                 |
-| -------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
-| [MoviePlus.user.js](scripts/MoviePlus.user.js)                             | 豆瓣电影页面右侧添加资源搜索入口                | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469243) |
-| [BiliTab.user.js](scripts/BiliTab.user.js)                                 | 劫持点击改为可后台新标签打开（支持开关/按键）   | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469242) |
-| [CodexUsageRemainingTime.user.js](scripts/CodexUsageRemainingTime.user.js) | Codex 分析页标出用量窗口时间刻度                | 不发布到 GreasyFork                                       |
-| [GitHubDeepWiki.user.js](scripts/GitHubDeepWiki.user.js)                   | 仓库标题旁添加 DeepWiki 按钮                    | 不发布到 GreasyFork                                       |
-| [GitHubDateNumeric.user.js](scripts/GitHubDateNumeric.user.js)             | GitHub 日期改为自定义数字/相对时间格式          | 不发布到 GreasyFork                                       |
+| 脚本                                                                               | 简介                                            | 状态/链接                                                 |
+| ---------------------------------------------------------------------------------- | ----------------------------------------------- | --------------------------------------------------------- |
+| [MoviePlus.user.js](scripts/MoviePlus.user.js)                                     | 豆瓣电影页面右侧添加资源搜索入口                | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469243) |
+| [BiliTab.user.js](scripts/BiliTab.user.js)                                         | 劫持点击改为可后台新标签打开（支持开关/按键）   | [GreasyFork](https://greasyfork.org/zh-CN/scripts/469242) |
+| [CodexUsageRemainingTime.user.js](scripts/CodexUsageRemainingTime.user.js)         | Codex 分析页标出用量窗口时间刻度                | 不发布到 GreasyFork                                       |
+| [GitHubDeepWiki.user.js](scripts/GitHubDeepWiki.user.js)                           | 仓库标题旁添加 DeepWiki 按钮                    | 不发布到 GreasyFork                                       |
+| [GitHubDateNumeric.user.js](scripts/GitHubDateNumeric.user.js)                     | GitHub 日期改为自定义数字/相对时间格式          | 不发布到 GreasyFork                                       |
 | [GitHubPrFileTreeReviewStats.user.js](scripts/GitHubPrFileTreeReviewStats.user.js) | GitHub PR 文件树显示增删行数与 Viewed 状态      | 不发布到 GreasyFork                                       |
-| [XTwitterImageWheel.user.js](scripts/XTwitterImageWheel.user.js)           | X/Twitter 图片详情页滚轮翻页                    | 不发布到 GreasyFork                                       |
-| [MediaSpeedToggle.user.js](scripts/MediaSpeedToggle.user.js)               | 全站视频 1x/3x 快捷切换，支持全局/站点/页面规则 | 不发布到 GreasyFork                                       |
-| [BiliBiliTweaks.user.js](scripts/BiliBiliTweaks.user.js)                   | B 站辅助脚本，自维护 fork                       | 不发布到 GreasyFork                                       |
+| [XTwitterImageWheel.user.js](scripts/XTwitterImageWheel.user.js)                   | X/Twitter 图片详情页滚轮翻页                    | 不发布到 GreasyFork                                       |
+| [MediaSpeedToggle.user.js](scripts/MediaSpeedToggle.user.js)                       | 全站视频 1x/3x 快捷切换，支持全局/站点/页面规则 | 不发布到 GreasyFork                                       |
+| [BiliBiliTweaks.user.js](scripts/BiliBiliTweaks.user.js)                           | B 站辅助脚本，自维护 fork                       | 不发布到 GreasyFork                                       |
 
 > `MediaSpeedToggle.user.js` 为 DCjanus 个人使用场景定制脚本，不追求通用性与可配置性。
 
 MoviePlus Fork 自 [94leon/movie.plus](https://github.com/94leon/movie.plus)
 
 BiliBiliTweaks Fork 自 [Make BiliBili Great Again](https://greasyfork.org/zh-CN/scripts/415714)，原作者 [kookxiang](https://greasyfork.org/zh-CN/users/188561-kookxiang)。导入基线为上游 `1.5.12`；上游未声明许可证，因此本仓库只保留自用维护副本与来源说明。
+
+# 开发
+
+提交前检查使用 [prek](https://prek.j178.dev/)：
+
+```bash
+prek install
+```

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,3 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json"
+}

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,22 @@
+minimum_prek_version = "0.4.8"
+
+[[repos]]
+repo = "builtin"
+hooks = [
+  { id = "check-json" },
+  { id = "check-toml" },
+  { id = "check-yaml" },
+  { id = "end-of-file-fixer" },
+  { id = "trailing-whitespace" },
+]
+
+[[repos]]
+repo = "local"
+
+[[repos.hooks]]
+id = "biome"
+name = "biome"
+language = "node"
+entry = "biome check"
+additional_dependencies = ["@biomejs/biome@latest"]
+files = "^(scripts/.*\\.user\\.js|biome\\.json)$"

--- a/scripts/BiliBiliTweaks.user.js
+++ b/scripts/BiliBiliTweaks.user.js
@@ -15,742 +15,734 @@
 
 // 去掉叔叔去世时的全站黑白效果
 GM_addStyle(
-    'html, body { -webkit-filter: none !important; filter: none !important; }',
+	"html, body { -webkit-filter: none !important; filter: none !important; }",
 );
 
 // 屏蔽屏蔽提示
 GM_addStyle(
-    '.adblock-tips, .feed-card:has(.bili-video-card>div:empty) { display: none !important; }',
+	".adblock-tips, .feed-card:has(.bili-video-card>div:empty) { display: none !important; }",
 );
 
 // 没用的 URL 参数
 const uselessUrlParams = [
-    'buvid',
-    'is_story_h5',
-    'launch_id',
-    'live_from',
-    'mid',
-    'session_id',
-    'timestamp',
-    'trackid',
-    'up_id',
-    'vd_source',
-    /^share/,
-    /^spm/,
+	"buvid",
+	"is_story_h5",
+	"launch_id",
+	"live_from",
+	"mid",
+	"session_id",
+	"timestamp",
+	"trackid",
+	"up_id",
+	"vd_source",
+	/^share/,
+	/^spm/,
 ];
 
 function getRequestUrl(input) {
-    if (typeof input === 'string') return input;
-    if (input instanceof URL || input instanceof unsafeWindow.URL) {
-        return input.toString();
-    }
-    if (input?.url) return input.url;
-    return undefined;
+	if (typeof input === "string") return input;
+	if (input instanceof URL || input instanceof unsafeWindow.URL) {
+		return input.toString();
+	}
+	if (input?.url) return input.url;
+	return undefined;
 }
 
 function replaceRequestUrl(input, url) {
-    if (typeof input === 'string') return url;
-    if (input instanceof URL || input instanceof unsafeWindow.URL) {
-        return new unsafeWindow.URL(url);
-    }
+	if (typeof input === "string") return url;
+	if (input instanceof URL || input instanceof unsafeWindow.URL) {
+		return new unsafeWindow.URL(url);
+	}
 
-    const RequestCtor = unsafeWindow.Request || globalThis.Request;
-    if (RequestCtor && input instanceof RequestCtor) {
-        return new RequestCtor(url, input);
-    }
+	const RequestCtor = unsafeWindow.Request || globalThis.Request;
+	if (RequestCtor && input instanceof RequestCtor) {
+		return new RequestCtor(url, input);
+	}
 
-    return url;
+	return url;
 }
 
 function defineReadonlyGlobal(name, value) {
-    try {
-        Object.defineProperty(unsafeWindow, name, {
-            get() {
-                return value;
-            },
-            set() {},
-            enumerable: false,
-            configurable: false,
-        });
-    } catch (e) {
-        try {
-            unsafeWindow[name] = value;
-        } catch (e) {}
-    }
+	try {
+		Object.defineProperty(unsafeWindow, name, {
+			get() {
+				return value;
+			},
+			set() {},
+			enumerable: false,
+			configurable: false,
+		});
+	} catch (_e) {
+		try {
+			unsafeWindow[name] = value;
+		} catch (_e) {}
+	}
 }
 
 // Block WebRTC，CNM 陈睿你就缺这点棺材钱？
 try {
-    class _RTCPeerConnection {
-        addEventListener() {}
-        createDataChannel() {}
-    }
-    class _RTCDataChannel {}
-    Object.defineProperty(unsafeWindow, 'RTCPeerConnection', {
-        value: _RTCPeerConnection,
-        enumerable: false,
-        writable: false,
-    });
-    Object.defineProperty(unsafeWindow, 'RTCDataChannel', {
-        value: _RTCDataChannel,
-        enumerable: false,
-        writable: false,
-    });
-    Object.defineProperty(unsafeWindow, 'webkitRTCPeerConnection', {
-        value: _RTCPeerConnection,
-        enumerable: false,
-        writable: false,
-    });
-    Object.defineProperty(unsafeWindow, 'webkitRTCDataChannel', {
-        value: _RTCDataChannel,
-        enumerable: false,
-        writable: false,
-    });
-} catch (e) {}
+	class _RTCPeerConnection {
+		addEventListener() {}
+		createDataChannel() {}
+	}
+	class _RTCDataChannel {}
+	Object.defineProperty(unsafeWindow, "RTCPeerConnection", {
+		value: _RTCPeerConnection,
+		enumerable: false,
+		writable: false,
+	});
+	Object.defineProperty(unsafeWindow, "RTCDataChannel", {
+		value: _RTCDataChannel,
+		enumerable: false,
+		writable: false,
+	});
+	Object.defineProperty(unsafeWindow, "webkitRTCPeerConnection", {
+		value: _RTCPeerConnection,
+		enumerable: false,
+		writable: false,
+	});
+	Object.defineProperty(unsafeWindow, "webkitRTCDataChannel", {
+		value: _RTCDataChannel,
+		enumerable: false,
+		writable: false,
+	});
+} catch (_e) {}
 
 // 移除鸿蒙字体，系统自带它不香吗？
 Array.from(
-    document.querySelectorAll('link[href*=\\/jinkela\\/long\\/font\\/]'),
-).forEach((x) => x.remove());
-GM_addStyle('html, body { font-family: initial !important; }');
+	document.querySelectorAll("link[href*=\\/jinkela\\/long\\/font\\/]"),
+).forEach((x) => {
+	x.remove();
+});
+GM_addStyle("html, body { font-family: initial !important; }");
 
 // 首页优化
-if (location.host === 'www.bilibili.com') {
-    GM_addStyle(
-        '.feed2 .feed-card:has(a[href*="cm.bilibili.com"]), .feed2 .feed-card:has(.bili-video-card:empty), .feed2 .feed-card.dcjanus-bili-hidden-ad-card { display: none !important } .feed2 .container > * { margin-top: 0 !important } #dcjanus-bili-ad-filter-status { position: fixed; right: 16px; bottom: 88px; z-index: 10000; padding: 3px 6px; border-radius: 4px; color: #fff; background: rgba(0, 0, 0, .45); font-size: 12px; line-height: 1.2; opacity: .35; pointer-events: auto; user-select: none; transition: opacity .15s ease, background .15s ease; } #dcjanus-bili-ad-filter-status:hover { opacity: .85; background: rgba(0, 0, 0, .65); } #dcjanus-bili-ad-filter-status[hidden] { display: none !important; }',
-    );
+if (location.host === "www.bilibili.com") {
+	GM_addStyle(
+		'.feed2 .feed-card:has(a[href*="cm.bilibili.com"]), .feed2 .feed-card:has(.bili-video-card:empty), .feed2 .feed-card.dcjanus-bili-hidden-ad-card { display: none !important } .feed2 .container > * { margin-top: 0 !important } #dcjanus-bili-ad-filter-status { position: fixed; right: 16px; bottom: 88px; z-index: 10000; padding: 3px 6px; border-radius: 4px; color: #fff; background: rgba(0, 0, 0, .45); font-size: 12px; line-height: 1.2; opacity: .35; pointer-events: auto; user-select: none; transition: opacity .15s ease, background .15s ease; } #dcjanus-bili-ad-filter-status:hover { opacity: .85; background: rgba(0, 0, 0, .65); } #dcjanus-bili-ad-filter-status[hidden] { display: none !important; }',
+	);
 
-    const hiddenHomeAdCards = new WeakSet();
-    let hiddenHomeAdCardCount = 0;
-    let renderedHomeAdCardCount = -1;
-    let homeAdFilterScheduled = false;
+	const hiddenHomeAdCards = new WeakSet();
+	let hiddenHomeAdCardCount = 0;
+	let renderedHomeAdCardCount = -1;
+	let homeAdFilterScheduled = false;
 
-    function ensureHomeAdFilterStatus() {
-        let status = document.querySelector('#dcjanus-bili-ad-filter-status');
-        if (status) return status;
+	function ensureHomeAdFilterStatus() {
+		let status = document.querySelector("#dcjanus-bili-ad-filter-status");
+		if (status) return status;
 
-        status = document.createElement('div');
-        status.id = 'dcjanus-bili-ad-filter-status';
-        status.hidden = true;
-        status.setAttribute('role', 'status');
-        status.setAttribute('aria-live', 'polite');
-        document.body.appendChild(status);
-        return status;
-    }
+		status = document.createElement("div");
+		status.id = "dcjanus-bili-ad-filter-status";
+		status.hidden = true;
+		status.setAttribute("role", "status");
+		status.setAttribute("aria-live", "polite");
+		document.body.appendChild(status);
+		return status;
+	}
 
-    function updateHomeAdFilterStatus() {
-        if (renderedHomeAdCardCount === hiddenHomeAdCardCount) return;
-        renderedHomeAdCardCount = hiddenHomeAdCardCount;
+	function updateHomeAdFilterStatus() {
+		if (renderedHomeAdCardCount === hiddenHomeAdCardCount) return;
+		renderedHomeAdCardCount = hiddenHomeAdCardCount;
 
-        if (hiddenHomeAdCardCount === 0) {
-            const status = document.querySelector(
-                '#dcjanus-bili-ad-filter-status',
-            );
-            if (status) status.hidden = true;
-            return;
-        }
+		if (hiddenHomeAdCardCount === 0) {
+			const status = document.querySelector("#dcjanus-bili-ad-filter-status");
+			if (status) status.hidden = true;
+			return;
+		}
 
-        const status = ensureHomeAdFilterStatus();
-        status.hidden = false;
-        status.textContent = `AD ${hiddenHomeAdCardCount}`;
-        status.title = `已过滤 ${hiddenHomeAdCardCount} 个首页广告`;
-        status.setAttribute(
-            'aria-label',
-            `已过滤 ${hiddenHomeAdCardCount} 个首页广告`,
-        );
-    }
+		const status = ensureHomeAdFilterStatus();
+		status.hidden = false;
+		status.textContent = `AD ${hiddenHomeAdCardCount}`;
+		status.title = `已过滤 ${hiddenHomeAdCardCount} 个首页广告`;
+		status.setAttribute(
+			"aria-label",
+			`已过滤 ${hiddenHomeAdCardCount} 个首页广告`,
+		);
+	}
 
-    function isHomeFeedAdCard(card) {
-        if (card.querySelector('a[href*="cm.bilibili.com"]')) return true;
-        if (card.querySelector('.bili-video-card:empty')) return true;
+	function isHomeFeedAdCard(card) {
+		if (card.querySelector('a[href*="cm.bilibili.com"]')) return true;
+		if (card.querySelector(".bili-video-card:empty")) return true;
 
-        const videoCard = card.querySelector('.bili-video-card');
-        if (!videoCard) return false;
+		const videoCard = card.querySelector(".bili-video-card");
+		if (!videoCard) return false;
 
-        const hasMiniProgramAction = videoCard.textContent.includes('去小程序');
-        const hasVideoEntry = card.querySelector(
-            'a[href*="/video/"], a[href*="/bangumi/play/"], a[href*="live.bilibili.com"]',
-        );
-        const title = videoCard.querySelector('.bili-video-card__info--tit');
-        const titleLink = title?.querySelector('a[href]');
+		const hasMiniProgramAction = videoCard.textContent.includes("去小程序");
+		const hasVideoEntry = card.querySelector(
+			'a[href*="/video/"], a[href*="/bangumi/play/"], a[href*="live.bilibili.com"]',
+		);
+		const title = videoCard.querySelector(".bili-video-card__info--tit");
+		const titleLink = title?.querySelector("a[href]");
 
-        return hasMiniProgramAction && title && !titleLink && !hasVideoEntry;
-    }
+		return hasMiniProgramAction && title && !titleLink && !hasVideoEntry;
+	}
 
-    function hideHomeFeedAdCards() {
-        homeAdFilterScheduled = false;
+	function hideHomeFeedAdCards() {
+		homeAdFilterScheduled = false;
 
-        document.querySelectorAll('.feed2 .feed-card').forEach((card) => {
-            if (hiddenHomeAdCards.has(card)) return;
-            if (!isHomeFeedAdCard(card)) return;
+		document.querySelectorAll(".feed2 .feed-card").forEach((card) => {
+			if (hiddenHomeAdCards.has(card)) return;
+			if (!isHomeFeedAdCard(card)) return;
 
-            hiddenHomeAdCards.add(card);
-            hiddenHomeAdCardCount += 1;
-            card.classList.add('dcjanus-bili-hidden-ad-card');
-        });
+			hiddenHomeAdCards.add(card);
+			hiddenHomeAdCardCount += 1;
+			card.classList.add("dcjanus-bili-hidden-ad-card");
+		});
 
-        updateHomeAdFilterStatus();
-    }
+		updateHomeAdFilterStatus();
+	}
 
-    function scheduleHomeFeedAdFilter() {
-        if (homeAdFilterScheduled) return;
-        homeAdFilterScheduled = true;
-        requestAnimationFrame(hideHomeFeedAdCards);
-    }
+	function scheduleHomeFeedAdFilter() {
+		if (homeAdFilterScheduled) return;
+		homeAdFilterScheduled = true;
+		requestAnimationFrame(hideHomeFeedAdCards);
+	}
 
-    scheduleHomeFeedAdFilter();
-    new MutationObserver(scheduleHomeFeedAdFilter).observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
+	scheduleHomeFeedAdFilter();
+	new MutationObserver(scheduleHomeFeedAdFilter).observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
 }
 
 // 动态页面优化
-if (location.host === 't.bilibili.com') {
-    GM_addStyle(
-        'html[wide] #app { display: flex; } html[wide] .bili-dyn-home--member { box-sizing: border-box;padding: 0 10px;width: 100%;flex: 1; } html[wide] .bili-dyn-content { width: initial; } html[wide] main { margin: 0 8px;flex: 1;overflow: hidden;width: initial; } #wide-mode-switch { margin-left: 0;margin-right: 20px; } #wide-mode-switch.floating { position: fixed; right: 24px; bottom: 24px; z-index: 10000; padding: 8px 12px; border-radius: 6px; color: #fff; background: #00aeec; box-shadow: 0 2px 10px rgba(0, 0, 0, .18); } .bili-dyn-list__item:has(.bili-dyn-card-goods), .bili-dyn-list__item:has(.bili-rich-text-module.goods) { display: none !important }',
-    );
-    if (!localStorage.WIDE_OPT_OUT) {
-        document.documentElement.setAttribute('wide', 'wide');
-    }
-    function injectWideModeSwitch() {
-        if (document.querySelector('#wide-mode-switch')) return true;
+if (location.host === "t.bilibili.com") {
+	GM_addStyle(
+		"html[wide] #app { display: flex; } html[wide] .bili-dyn-home--member { box-sizing: border-box;padding: 0 10px;width: 100%;flex: 1; } html[wide] .bili-dyn-content { width: initial; } html[wide] main { margin: 0 8px;flex: 1;overflow: hidden;width: initial; } #wide-mode-switch { margin-left: 0;margin-right: 20px; } #wide-mode-switch.floating { position: fixed; right: 24px; bottom: 24px; z-index: 10000; padding: 8px 12px; border-radius: 6px; color: #fff; background: #00aeec; box-shadow: 0 2px 10px rgba(0, 0, 0, .18); } .bili-dyn-list__item:has(.bili-dyn-card-goods), .bili-dyn-list__item:has(.bili-rich-text-module.goods) { display: none !important }",
+	);
+	if (!localStorage.WIDE_OPT_OUT) {
+		document.documentElement.setAttribute("wide", "wide");
+	}
+	function injectWideModeSwitch() {
+		if (document.querySelector("#wide-mode-switch")) return true;
 
-        const tabContainer =
-            document.querySelector('.bili-dyn-list-tabs__list') ||
-            document.querySelector('.bili-dyn-content') ||
-            document.querySelector('main');
-        if (!tabContainer) return false;
+		const tabContainer =
+			document.querySelector(".bili-dyn-list-tabs__list") ||
+			document.querySelector(".bili-dyn-content") ||
+			document.querySelector("main");
+		if (!tabContainer) return false;
 
-        const switchButton = document.createElement('a');
-        switchButton.id = 'wide-mode-switch';
-        switchButton.className = 'bili-dyn-list-tabs__item';
-        switchButton.textContent = '宽屏模式';
-        switchButton.addEventListener('click', function (e) {
-            e.preventDefault();
-            if (localStorage.WIDE_OPT_OUT) {
-                localStorage.removeItem('WIDE_OPT_OUT');
-                document.documentElement.setAttribute('wide', 'wide');
-            } else {
-                localStorage.setItem('WIDE_OPT_OUT', '1');
-                document.documentElement.removeAttribute('wide');
-            }
-        });
+		const switchButton = document.createElement("a");
+		switchButton.id = "wide-mode-switch";
+		switchButton.className = "bili-dyn-list-tabs__item";
+		switchButton.textContent = "宽屏模式";
+		switchButton.addEventListener("click", (e) => {
+			e.preventDefault();
+			if (localStorage.WIDE_OPT_OUT) {
+				localStorage.removeItem("WIDE_OPT_OUT");
+				document.documentElement.setAttribute("wide", "wide");
+			} else {
+				localStorage.setItem("WIDE_OPT_OUT", "1");
+				document.documentElement.removeAttribute("wide");
+			}
+		});
 
-        if (tabContainer.matches('.bili-dyn-list-tabs__list')) {
-            const placeHolder = document.createElement('div');
-            placeHolder.style.flex = 1;
-            tabContainer.appendChild(placeHolder);
-        } else {
-            switchButton.classList.add('floating');
-        }
-        tabContainer.appendChild(switchButton);
-        return true;
-    }
-    window.addEventListener('load', function () {
-        if (injectWideModeSwitch()) return;
-        const observer = new MutationObserver(() => {
-            if (injectWideModeSwitch()) observer.disconnect();
-        });
-        observer.observe(document.body, { childList: true, subtree: true });
-    });
+		if (tabContainer.matches(".bili-dyn-list-tabs__list")) {
+			const placeHolder = document.createElement("div");
+			placeHolder.style.flex = 1;
+			tabContainer.appendChild(placeHolder);
+		} else {
+			switchButton.classList.add("floating");
+		}
+		tabContainer.appendChild(switchButton);
+		return true;
+	}
+	window.addEventListener("load", () => {
+		if (injectWideModeSwitch()) return;
+		const observer = new MutationObserver(() => {
+			if (injectWideModeSwitch()) observer.disconnect();
+		});
+		observer.observe(document.body, { childList: true, subtree: true });
+	});
 }
 
 // 去广告
 GM_addStyle(
-    '.ad-report, a[href*="cm.bilibili.com"] { display: none !important; }',
+	'.ad-report, a[href*="cm.bilibili.com"] { display: none !important; }',
 );
 if (unsafeWindow.__INITIAL_STATE__?.adData) {
-    for (const key in unsafeWindow.__INITIAL_STATE__.adData) {
-        if (!Array.isArray(unsafeWindow.__INITIAL_STATE__.adData[key]))
-            continue;
-        for (const item of unsafeWindow.__INITIAL_STATE__.adData[key]) {
-            item.name = 'B 站未来有可能会倒闭，但绝不会变质';
-            item.pic = 'https://static.hdslb.com/images/transparent.gif';
-            item.url = 'https://space.bilibili.com/208259';
-        }
-    }
+	for (const key in unsafeWindow.__INITIAL_STATE__.adData) {
+		if (!Array.isArray(unsafeWindow.__INITIAL_STATE__.adData[key])) continue;
+		for (const item of unsafeWindow.__INITIAL_STATE__.adData[key]) {
+			item.name = "B 站未来有可能会倒闭，但绝不会变质";
+			item.pic = "https://static.hdslb.com/images/transparent.gif";
+			item.url = "https://space.bilibili.com/208259";
+		}
+	}
 }
 
 // 去充电列表（叔叔的跳过按钮越做越小了，就尼玛离谱）
 if (unsafeWindow.__INITIAL_STATE__?.elecFullInfo) {
-    unsafeWindow.__INITIAL_STATE__.elecFullInfo.list = [];
+	unsafeWindow.__INITIAL_STATE__.elecFullInfo.list = [];
 }
 
 // 修复文章区复制
 if (
-    location.href.startsWith('https://www.bilibili.com/read/cv') ||
-    location.href.startsWith('https://www.bilibili.com/opus/')
+	location.href.startsWith("https://www.bilibili.com/read/cv") ||
+	location.href.startsWith("https://www.bilibili.com/opus/")
 ) {
-    if (unsafeWindow.original) unsafeWindow.original.reprint = '1';
+	if (unsafeWindow.original) unsafeWindow.original.reprint = "1";
 
-    function unlockArticleCopy() {
-        document
-            .querySelectorAll('.article-holder, .opus-module-content')
-            .forEach((holder) => {
-                holder.classList.remove('unable-reprint');
-            });
-    }
+	function unlockArticleCopy() {
+		document
+			.querySelectorAll(".article-holder, .opus-module-content")
+			.forEach((holder) => {
+				holder.classList.remove("unable-reprint");
+			});
+	}
 
-    document.addEventListener(
-        'copy',
-        (e) => e.stopImmediatePropagation(),
-        true,
-    );
-    unlockArticleCopy();
-    window.addEventListener('load', unlockArticleCopy);
-    new MutationObserver(unlockArticleCopy).observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
+	document.addEventListener("copy", (e) => e.stopImmediatePropagation(), true);
+	unlockArticleCopy();
+	window.addEventListener("load", unlockArticleCopy);
+	new MutationObserver(unlockArticleCopy).observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
 }
 
 // 去 P2P CDN
-Object.defineProperty(unsafeWindow, 'PCDNLoader', {
-    value: class {},
-    enumerable: false,
-    writable: false,
+Object.defineProperty(unsafeWindow, "PCDNLoader", {
+	value: class {},
+	enumerable: false,
+	writable: false,
 });
-Object.defineProperty(unsafeWindow, 'BPP2PSDK', {
-    value: class {
-        on() {}
-    },
-    enumerable: false,
-    writable: false,
+Object.defineProperty(unsafeWindow, "BPP2PSDK", {
+	value: class {
+		on() {}
+	},
+	enumerable: false,
+	writable: false,
 });
-Object.defineProperty(unsafeWindow, 'SeederSDK', {
-    value: class {},
-    enumerable: false,
-    writable: false,
+Object.defineProperty(unsafeWindow, "SeederSDK", {
+	value: class {},
+	enumerable: false,
+	writable: false,
 });
 if (
-    location.href.startsWith('https://www.bilibili.com/video/') ||
-    location.href.startsWith('https://www.bilibili.com/bangumi/play/')
+	location.href.startsWith("https://www.bilibili.com/video/") ||
+	location.href.startsWith("https://www.bilibili.com/bangumi/play/")
 ) {
-    let cdnDomain;
+	let cdnDomain;
 
-    function replaceP2PUrl(url) {
-        cdnDomain ||= document.head.innerHTML.match(
-            /up[\w-]+\.bilivideo\.com/,
-        )?.[0];
+	function replaceP2PUrl(url) {
+		cdnDomain ||= document.head.innerHTML.match(
+			/up[\w-]+\.bilivideo\.com/,
+		)?.[0];
 
-        try {
-            const urlObj = new URL(url);
-            const hostName = urlObj.hostname;
-            if (urlObj.hostname.endsWith('.mcdn.bilivideo.cn')) {
-                urlObj.host = cdnDomain || 'upos-sz-mirrorcoso1.bilivideo.com';
-                urlObj.port = 443;
-                console.warn(`更换视频源: ${hostName} -> ${urlObj.host}`);
-                return urlObj.toString();
-            } else if (urlObj.hostname.endsWith('.szbdyd.com')) {
-                urlObj.host = urlObj.searchParams.get('xy_usource');
-                urlObj.port = 443;
-                console.warn(`更换视频源: ${hostName} -> ${urlObj.host}`);
-                return urlObj.toString();
-            }
-            return url;
-        } catch (e) {
-            return url;
-        }
-    }
+		try {
+			const urlObj = new URL(url);
+			const hostName = urlObj.hostname;
+			if (urlObj.hostname.endsWith(".mcdn.bilivideo.cn")) {
+				urlObj.host = cdnDomain || "upos-sz-mirrorcoso1.bilivideo.com";
+				urlObj.port = 443;
+				console.warn(`更换视频源: ${hostName} -> ${urlObj.host}`);
+				return urlObj.toString();
+			} else if (urlObj.hostname.endsWith(".szbdyd.com")) {
+				urlObj.host = urlObj.searchParams.get("xy_usource");
+				urlObj.port = 443;
+				console.warn(`更换视频源: ${hostName} -> ${urlObj.host}`);
+				return urlObj.toString();
+			}
+			return url;
+		} catch (_e) {
+			return url;
+		}
+	}
 
-    function replaceP2PUrlDeep(obj) {
-        if (!obj || typeof obj !== 'object') return;
-        for (const key in obj) {
-            if (typeof obj[key] === 'string') {
-                obj[key] = replaceP2PUrl(obj[key]);
-            } else if (
-                Array.isArray(obj[key]) ||
-                typeof obj[key] === 'object'
-            ) {
-                replaceP2PUrlDeep(obj[key]);
-            }
-        }
-    }
+	function replaceP2PUrlDeep(obj) {
+		if (!obj || typeof obj !== "object") return;
+		for (const key in obj) {
+			if (typeof obj[key] === "string") {
+				obj[key] = replaceP2PUrl(obj[key]);
+			} else if (Array.isArray(obj[key]) || typeof obj[key] === "object") {
+				replaceP2PUrlDeep(obj[key]);
+			}
+		}
+	}
 
-    replaceP2PUrlDeep(unsafeWindow.__playinfo__);
+	replaceP2PUrlDeep(unsafeWindow.__playinfo__);
 
-    (function (HTMLMediaElementPrototypeSrcDescriptor) {
-        Object.defineProperty(unsafeWindow.HTMLMediaElement.prototype, 'src', {
-            ...HTMLMediaElementPrototypeSrcDescriptor,
-            set: function (value) {
-                HTMLMediaElementPrototypeSrcDescriptor.set.call(
-                    this,
-                    replaceP2PUrl(value),
-                );
-            },
-        });
-    })(
-        Object.getOwnPropertyDescriptor(
-            unsafeWindow.HTMLMediaElement.prototype,
-            'src',
-        ),
-    );
+	((HTMLMediaElementPrototypeSrcDescriptor) => {
+		Object.defineProperty(unsafeWindow.HTMLMediaElement.prototype, "src", {
+			...HTMLMediaElementPrototypeSrcDescriptor,
+			set: function (value) {
+				HTMLMediaElementPrototypeSrcDescriptor.set.call(
+					this,
+					replaceP2PUrl(value),
+				);
+			},
+		});
+	})(
+		Object.getOwnPropertyDescriptor(
+			unsafeWindow.HTMLMediaElement.prototype,
+			"src",
+		),
+	);
 
-    (function (open) {
-        unsafeWindow.XMLHttpRequest.prototype.open = function () {
-            try {
-                arguments[1] = replaceP2PUrl(arguments[1]);
-            } finally {
-                return open.apply(this, arguments);
-            }
-        };
-    })(unsafeWindow.XMLHttpRequest.prototype.open);
+	((open) => {
+		unsafeWindow.XMLHttpRequest.prototype.open = function (...args) {
+			args[1] = replaceP2PUrl(args[1]);
+			return open.apply(this, args);
+		};
+	})(unsafeWindow.XMLHttpRequest.prototype.open);
 }
 
 // 真·原画直播
-if (location.href.startsWith('https://live.bilibili.com/')) {
-    const LIVE_PLAY_INFO_PATH = '/xlive/web-room/v2/index/getRoomPlayInfo';
+if (location.href.startsWith("https://live.bilibili.com/")) {
+	const LIVE_PLAY_INFO_PATH = "/xlive/web-room/v2/index/getRoomPlayInfo";
 
-    unsafeWindow.disableLiveP2P = true;
-    unsafeWindow.forceHighestQuality =
-        localStorage.getItem('forceHighestQuality') === 'true';
-    let recentErrors = 0;
-    setInterval(() => {
-        recentErrors = Math.floor(recentErrors / 2);
-    }, 10000);
+	unsafeWindow.disableLiveP2P = true;
+	unsafeWindow.forceHighestQuality =
+		localStorage.getItem("forceHighestQuality") === "true";
+	let recentErrors = 0;
+	setInterval(() => {
+		recentErrors = Math.floor(recentErrors / 2);
+	}, 10000);
 
-    function isLivePlayInfoUrl(url) {
-        try {
-            return new URL(url, location.href).pathname === LIVE_PLAY_INFO_PATH;
-        } catch (e) {
-            return false;
-        }
-    }
+	function isLivePlayInfoUrl(url) {
+		try {
+			return new URL(url, location.href).pathname === LIVE_PLAY_INFO_PATH;
+		} catch (_e) {
+			return false;
+		}
+	}
 
-    function preferHighestLiveQuality(input) {
-        const url = getRequestUrl(input);
-        if (!unsafeWindow.forceHighestQuality || !url) return input;
+	function preferHighestLiveQuality(input) {
+		const url = getRequestUrl(input);
+		if (!unsafeWindow.forceHighestQuality || !url) return input;
 
-        try {
-            const urlObj = new URL(url, location.href);
-            if (urlObj.pathname !== LIVE_PLAY_INFO_PATH) return input;
-            urlObj.searchParams.set('qn', '30000');
-            return replaceRequestUrl(input, urlObj.toString());
-        } catch (e) {
-            return input;
-        }
-    }
+		try {
+			const urlObj = new URL(url, location.href);
+			if (urlObj.pathname !== LIVE_PLAY_INFO_PATH) return input;
+			urlObj.searchParams.set("qn", "30000");
+			return replaceRequestUrl(input, urlObj.toString());
+		} catch (_e) {
+			return input;
+		}
+	}
 
-    function rewriteLiveMediaUrl(url) {
-        const mcdnRegexp = /[xy0-9]+\.mcdn\.bilivideo\.cn:\d+/;
-        const smtcdnsRegexp = /[\w.]+\.smtcdns.net\/([\w-]+\.bilivideo.com\/)/;
-        const qualityRegexp = /(live-bvc\/\d+\/live_\d+_\d+)_\w+/;
+	function rewriteLiveMediaUrl(url) {
+		const mcdnRegexp = /[xy0-9]+\.mcdn\.bilivideo\.cn:\d+/;
+		const smtcdnsRegexp = /[\w.]+\.smtcdns.net\/([\w-]+\.bilivideo.com\/)/;
+		const qualityRegexp = /(live-bvc\/\d+\/live_\d+_\d+)_\w+/;
 
-        if (mcdnRegexp.test(url) && unsafeWindow.disableLiveP2P) {
-            return { blocked: true, url };
-        }
-        if (smtcdnsRegexp.test(url) && unsafeWindow.disableLiveP2P) {
-            return { blocked: false, url: url.replace(smtcdnsRegexp, '$1') };
-        }
-        if (qualityRegexp.test(url) && unsafeWindow.forceHighestQuality) {
-            return {
-                blocked: false,
-                url: url
-                    .replace(qualityRegexp, '$1')
-                    .replace(/(\d+)_(mini|pro)hevc/g, '$1'),
-            };
-        }
-        return { blocked: false, url };
-    }
+		if (mcdnRegexp.test(url) && unsafeWindow.disableLiveP2P) {
+			return { blocked: true, url };
+		}
+		if (smtcdnsRegexp.test(url) && unsafeWindow.disableLiveP2P) {
+			return { blocked: false, url: url.replace(smtcdnsRegexp, "$1") };
+		}
+		if (qualityRegexp.test(url) && unsafeWindow.forceHighestQuality) {
+			return {
+				blocked: false,
+				url: url
+					.replace(qualityRegexp, "$1")
+					.replace(/(\d+)_(mini|pro)hevc/g, "$1"),
+			};
+		}
+		return { blocked: false, url };
+	}
 
-    function disableLiveP2PInPayload(payload) {
-        const seen = new WeakSet();
+	function disableLiveP2PInPayload(payload) {
+		const seen = new WeakSet();
 
-        function walk(obj) {
-            if (!obj || typeof obj !== 'object' || seen.has(obj)) return;
-            seen.add(obj);
+		function walk(obj) {
+			if (!obj || typeof obj !== "object" || seen.has(obj)) return;
+			seen.add(obj);
 
-            if (obj.p2p_data && typeof obj.p2p_data === 'object') {
-                obj.p2p_data.p2p_type = 0;
-            }
-            if (Object.prototype.hasOwnProperty.call(obj, 'need_p2p')) {
-                obj.need_p2p = 0;
-            }
+			if (obj.p2p_data && typeof obj.p2p_data === "object") {
+				obj.p2p_data.p2p_type = 0;
+			}
+			if (Object.hasOwn(obj, "need_p2p")) {
+				obj.need_p2p = 0;
+			}
 
-            for (const key in obj) walk(obj[key]);
-        }
+			for (const key in obj) walk(obj[key]);
+		}
 
-        walk(payload);
-        return payload;
-    }
+		walk(payload);
+		return payload;
+	}
 
-    function livePlayInfoResponse(response, payload) {
-        const headers = new unsafeWindow.Headers(response.headers);
-        headers.delete('content-length');
-        headers.delete('content-encoding');
-        headers.set('content-type', 'application/json; charset=utf-8');
+	function livePlayInfoResponse(response, payload) {
+		const headers = new unsafeWindow.Headers(response.headers);
+		headers.delete("content-length");
+		headers.delete("content-encoding");
+		headers.set("content-type", "application/json; charset=utf-8");
 
-        return new unsafeWindow.Response(JSON.stringify(payload), {
-            status: response.status,
-            statusText: response.statusText,
-            headers,
-        });
-    }
+		return new unsafeWindow.Response(JSON.stringify(payload), {
+			status: response.status,
+			statusText: response.statusText,
+			headers,
+		});
+	}
 
-    const oldFetch = unsafeWindow.fetch;
-    unsafeWindow.fetch = function () {
-        const args = Array.from(arguments);
-        try {
-            args[0] = preferHighestLiveQuality(args[0]);
-            const url = getRequestUrl(args[0]);
-            if (url) {
-                const rewritten = rewriteLiveMediaUrl(url);
-                if (rewritten.blocked) {
-                    return Promise.reject(
-                        new TypeError('Blocked live P2P URL'),
-                    );
-                }
-                if (rewritten.url !== url) {
-                    args[0] = replaceRequestUrl(args[0], rewritten.url);
-                }
-            }
+	const oldFetch = unsafeWindow.fetch;
+	unsafeWindow.fetch = function (...args) {
+		try {
+			args[0] = preferHighestLiveQuality(args[0]);
+			const url = getRequestUrl(args[0]);
+			if (url) {
+				const rewritten = rewriteLiveMediaUrl(url);
+				if (rewritten.blocked) {
+					return Promise.reject(new TypeError("Blocked live P2P URL"));
+				}
+				if (rewritten.url !== url) {
+					args[0] = replaceRequestUrl(args[0], rewritten.url);
+				}
+			}
 
-            const requestUrl = getRequestUrl(args[0]) || '';
-            return oldFetch.apply(this, args).then(async (response) => {
-                const responseUrl = response.url || requestUrl;
-                if (/\.(m3u8|m4s)(?:[?#]|$)/.test(responseUrl)) {
-                    if ([403, 404].includes(response.status)) recentErrors++;
-                }
-                if (recentErrors >= 5 && unsafeWindow.forceHighestQuality) {
-                    recentErrors = 0;
-                    unsafeWindow.forceHighestQuality = false;
-                    GM_notification({
-                        title: '最高清晰度可能不可用',
-                        text: '已为您自动切换至播放器上选择的清晰度.',
-                        timeout: 3000,
-                        silent: true,
-                    });
-                }
-                if (!isLivePlayInfoUrl(requestUrl)) return response;
+			const requestUrl = getRequestUrl(args[0]) || "";
+			return oldFetch.apply(this, args).then(async (response) => {
+				const responseUrl = response.url || requestUrl;
+				if (/\.(m3u8|m4s)(?:[?#]|$)/.test(responseUrl)) {
+					if ([403, 404].includes(response.status)) recentErrors++;
+				}
+				if (recentErrors >= 5 && unsafeWindow.forceHighestQuality) {
+					recentErrors = 0;
+					unsafeWindow.forceHighestQuality = false;
+					GM_notification({
+						title: "最高清晰度可能不可用",
+						text: "已为您自动切换至播放器上选择的清晰度.",
+						timeout: 3000,
+						silent: true,
+					});
+				}
+				if (!isLivePlayInfoUrl(requestUrl)) return response;
 
-                try {
-                    const payload = await response.clone().json();
-                    return livePlayInfoResponse(
-                        response,
-                        disableLiveP2PInPayload(payload),
-                    );
-                } catch (e) {
-                    return response;
-                }
-            });
-        } catch (e) {}
-        return oldFetch.apply(this, args);
-    };
+				try {
+					const payload = await response.clone().json();
+					return livePlayInfoResponse(
+						response,
+						disableLiveP2PInPayload(payload),
+					);
+				} catch (_e) {
+					return response;
+				}
+			});
+		} catch (_e) {}
+		return oldFetch.apply(this, args);
+	};
 
-    // 干掉些直播间没用的东西
-    GM_addStyle(
-        '#welcome-area-bottom-vm, .web-player-icon-roomStatus { display: none !important; }',
-    );
+	// 干掉些直播间没用的东西
+	GM_addStyle(
+		"#welcome-area-bottom-vm, .web-player-icon-roomStatus { display: none !important; }",
+	);
 }
 
 // 视频裁切
-if (location.href.startsWith('https://www.bilibili.com/video/')) {
-    GM_addStyle(
-        'body[video-fit] #bilibili-player video { object-fit: cover; } .bpx-player-ctrl-setting-fit-mode { display: flex;width: 100%;height: 32px;line-height: 32px; } .bpx-player-ctrl-setting-box .bui-panel-wrap, .bpx-player-ctrl-setting-box .bui-panel-item { min-height: 172px !important; }',
-    );
-    let timer;
-    function toggleMode(enabled) {
-        if (enabled) {
-            document.body.setAttribute('video-fit', '');
-        } else {
-            document.body.removeAttribute('video-fit');
-        }
-    }
-    function injectButton() {
-        if (!document.querySelector('.bpx-player-ctrl-setting-menu-left')) {
-            return;
-        }
-        clearInterval(timer);
-        const parent = document.querySelector(
-            '.bpx-player-ctrl-setting-menu-left',
-        );
-        const item = document.createElement('div');
-        item.className = 'bpx-player-ctrl-setting-fit-mode bui bui-switch';
-        item.innerHTML =
-            '<input class="bui-switch-input" type="checkbox"><label class="bui-switch-label"><span class="bui-switch-name">裁切模式</span><span class="bui-switch-body"><span class="bui-switch-dot"><span></span></span></span></label>';
-        parent.insertBefore(
-            item,
-            document.querySelector('.bpx-player-ctrl-setting-more'),
-        );
-        document
-            .querySelector('.bpx-player-ctrl-setting-fit-mode input')
-            .addEventListener('change', (e) => toggleMode(e.target.checked));
-        document.querySelector(
-            '.bpx-player-ctrl-setting-box .bui-panel-item',
-        ).style.height = '';
-    }
-    timer = setInterval(injectButton, 200);
+if (location.href.startsWith("https://www.bilibili.com/video/")) {
+	GM_addStyle(
+		"body[video-fit] #bilibili-player video { object-fit: cover; } .bpx-player-ctrl-setting-fit-mode { display: flex;width: 100%;height: 32px;line-height: 32px; } .bpx-player-ctrl-setting-box .bui-panel-wrap, .bpx-player-ctrl-setting-box .bui-panel-item { min-height: 172px !important; }",
+	);
+	let timer;
+	function toggleMode(enabled) {
+		if (enabled) {
+			document.body.setAttribute("video-fit", "");
+		} else {
+			document.body.removeAttribute("video-fit");
+		}
+	}
+	function injectButton() {
+		if (!document.querySelector(".bpx-player-ctrl-setting-menu-left")) {
+			return;
+		}
+		clearInterval(timer);
+		const parent = document.querySelector(".bpx-player-ctrl-setting-menu-left");
+		const item = document.createElement("div");
+		item.className = "bpx-player-ctrl-setting-fit-mode bui bui-switch";
+		item.innerHTML =
+			'<input class="bui-switch-input" type="checkbox"><label class="bui-switch-label"><span class="bui-switch-name">裁切模式</span><span class="bui-switch-body"><span class="bui-switch-dot"><span></span></span></span></label>';
+		parent.insertBefore(
+			item,
+			document.querySelector(".bpx-player-ctrl-setting-more"),
+		);
+		document
+			.querySelector(".bpx-player-ctrl-setting-fit-mode input")
+			.addEventListener("change", (e) => toggleMode(e.target.checked));
+		document.querySelector(
+			".bpx-player-ctrl-setting-box .bui-panel-item",
+		).style.height = "";
+	}
+	timer = setInterval(injectButton, 200);
 }
 
 // 去除地址栏多余参数
 unsafeWindow.history.replaceState(
-    undefined,
-    undefined,
-    removeTracking(location.href),
+	undefined,
+	undefined,
+	removeTracking(location.href),
 );
 const pushState = unsafeWindow.history.pushState;
 unsafeWindow.history.pushState = function (state, unused, url) {
-    return pushState.apply(this, [state, unused, removeTracking(url)]);
+	return pushState.apply(this, [state, unused, removeTracking(url)]);
 };
 const replaceState = unsafeWindow.history.replaceState;
 unsafeWindow.history.replaceState = function (state, unused, url) {
-    return replaceState.apply(this, [state, unused, removeTracking(url)]);
+	return replaceState.apply(this, [state, unused, removeTracking(url)]);
 };
 
 function removeTracking(url) {
-    if (!url) return url;
-    try {
-        const urlObj = new URL(url, location.href);
-        if (!urlObj.search) return url;
-        const searchParams = urlObj.searchParams;
-        const keys = Array.from(searchParams.keys());
-        for (const key of keys) {
-            uselessUrlParams.forEach((item) => {
-                if (typeof item === 'string') {
-                    if (item === key) searchParams.delete(key);
-                } else if (item instanceof RegExp) {
-                    if (item.test(key)) searchParams.delete(key);
-                }
-            });
-        }
-        urlObj.search = searchParams.toString();
-        return urlObj.toString();
-    } catch (e) {
-        console.error(e);
-        return url;
-    }
+	if (!url) return url;
+	try {
+		const urlObj = new URL(url, location.href);
+		if (!urlObj.search) return url;
+		const searchParams = urlObj.searchParams;
+		const keys = Array.from(searchParams.keys());
+		for (const key of keys) {
+			uselessUrlParams.forEach((item) => {
+				if (typeof item === "string") {
+					if (item === key) searchParams.delete(key);
+				} else if (item instanceof RegExp) {
+					if (item.test(key)) searchParams.delete(key);
+				}
+			});
+		}
+		urlObj.search = searchParams.toString();
+		return urlObj.toString();
+	} catch (e) {
+		console.error(e);
+		return url;
+	}
 }
 
 // 去掉 B 站的傻逼上报
-!(function () {
-    const oldFetch = unsafeWindow.fetch;
-    unsafeWindow.fetch = function (input) {
-        const url = getRequestUrl(input);
-        if (typeof url === 'string' && url.match(/(?:cm|data)\.bilibili\.com/))
-            return new Promise(function () {});
-        return oldFetch.apply(this, arguments);
-    };
-    const oldOpen = unsafeWindow.XMLHttpRequest.prototype.open;
-    unsafeWindow.XMLHttpRequest.prototype.open = function (method, url) {
-        const requestUrl = getRequestUrl(url);
-        if (
-            typeof requestUrl === 'string' &&
-            requestUrl.match(/(?:cm|data)\.bilibili\.com/)
-        ) {
-            this.send = function () {};
-        }
-        return oldOpen.apply(this, arguments);
-    };
+!(() => {
+	const oldFetch = unsafeWindow.fetch;
+	unsafeWindow.fetch = function (input, ...args) {
+		const url = getRequestUrl(input);
+		if (typeof url === "string" && url.match(/(?:cm|data)\.bilibili\.com/))
+			return new Promise(() => {});
+		return oldFetch.call(this, input, ...args);
+	};
+	const oldOpen = unsafeWindow.XMLHttpRequest.prototype.open;
+	unsafeWindow.XMLHttpRequest.prototype.open = function (
+		_method,
+		url,
+		...args
+	) {
+		const requestUrl = getRequestUrl(url);
+		if (
+			typeof requestUrl === "string" &&
+			requestUrl.match(/(?:cm|data)\.bilibili\.com/)
+		) {
+			this.send = () => {};
+		}
+		return oldOpen.call(this, _method, url, ...args);
+	};
 
-    try {
-        Object.defineProperty(unsafeWindow.navigator, 'sendBeacon', {
-            value: () => true,
-            enumerable: false,
-            writable: false,
-            configurable: false,
-        });
-    } catch (e) {
-        unsafeWindow.navigator.sendBeacon = () => true;
-    }
+	try {
+		Object.defineProperty(unsafeWindow.navigator, "sendBeacon", {
+			value: () => true,
+			enumerable: false,
+			writable: false,
+			configurable: false,
+		});
+	} catch (_e) {
+		unsafeWindow.navigator.sendBeacon = () => true;
+	}
 
-    const fakeMReporterInstance = new Proxy(function () {}, {
-        get(target, prop) {
-            debugLog(`MReporterInstance.${prop} called with`, arguments);
-            return () => {};
-        },
-    });
-    defineReadonlyGlobal('MReporterInstance', fakeMReporterInstance);
+	const fakeMReporterInstance = new Proxy(() => {}, {
+		get(...args) {
+			const [, prop] = args;
+			debugLog(`MReporterInstance.${prop} called with`, args);
+			return () => {};
+		},
+	});
+	defineReadonlyGlobal("MReporterInstance", fakeMReporterInstance);
 
-    const fakeMReporter = new Proxy(function () {}, {
-        construct() {
-            return fakeMReporterInstance;
-        },
-        get(target, prop) {
-            debugLog(`MReporter.${prop} called with`, arguments);
-            return () => {};
-        },
-    });
-    defineReadonlyGlobal('MReporter', fakeMReporter);
+	const fakeMReporter = new Proxy(() => {}, {
+		construct() {
+			return fakeMReporterInstance;
+		},
+		get(...args) {
+			const [, prop] = args;
+			debugLog(`MReporter.${prop} called with`, args);
+			return () => {};
+		},
+	});
+	defineReadonlyGlobal("MReporter", fakeMReporter);
 
-    const sentryHub = class {
-        bindClient() {}
-    };
-    const fakeSentry = {
-        SDK_NAME: 'sentry.javascript.browser',
-        SDK_VERSION: '0.0.0',
-        BrowserClient: class {},
-        Hub: sentryHub,
-        Integrations: {
-            Vue: class {},
-            GlobalHandlers: class {},
-            InboundFilters: class {},
-        },
-        init() {},
-        configureScope() {},
-        getCurrentHub: () => new sentryHub(),
-        setContext() {},
-        setExtra() {},
-        setExtras() {},
-        setTag() {},
-        setTags() {},
-        setUser() {},
-        wrap() {},
-    };
-    if (
-        !unsafeWindow.Sentry ||
-        unsafeWindow.Sentry.SDK_VERSION !== fakeSentry.SDK_VERSION
-    ) {
-        if (unsafeWindow.Sentry) {
-            delete unsafeWindow.Sentry;
-        }
-        defineReadonlyGlobal('Sentry', fakeSentry);
-    }
+	const sentryHub = class {
+		bindClient() {}
+	};
+	const fakeSentry = {
+		SDK_NAME: "sentry.javascript.browser",
+		SDK_VERSION: "0.0.0",
+		BrowserClient: class {},
+		Hub: sentryHub,
+		Integrations: {
+			Vue: class {},
+			GlobalHandlers: class {},
+			InboundFilters: class {},
+		},
+		init() {},
+		configureScope() {},
+		getCurrentHub: () => new sentryHub(),
+		setContext() {},
+		setExtra() {},
+		setExtras() {},
+		setTag() {},
+		setTags() {},
+		setUser() {},
+		wrap() {},
+	};
+	if (
+		!unsafeWindow.Sentry ||
+		unsafeWindow.Sentry.SDK_VERSION !== fakeSentry.SDK_VERSION
+	) {
+		if (unsafeWindow.Sentry) {
+			delete unsafeWindow.Sentry;
+		}
+		defineReadonlyGlobal("Sentry", fakeSentry);
+	}
 
-    const fakeReporterPbInstance = new Proxy(function () {}, {
-        get(target, prop) {
-            debugLog(`ReporterPbInstance.${prop} called with`, arguments);
-            return () => {};
-        },
-    });
-    defineReadonlyGlobal('ReporterPbInstance', fakeReporterPbInstance);
+	const fakeReporterPbInstance = new Proxy(() => {}, {
+		get(...args) {
+			const [, prop] = args;
+			debugLog(`ReporterPbInstance.${prop} called with`, args);
+			return () => {};
+		},
+	});
+	defineReadonlyGlobal("ReporterPbInstance", fakeReporterPbInstance);
 
-    const fakeReporterPb = new Proxy(function () {}, {
-        construct() {
-            return fakeReporterPbInstance;
-        },
-        get(target, prop) {
-            debugLog(`ReporterPb.${prop} called with`, arguments);
-            return () => {};
-        },
-    });
-    defineReadonlyGlobal('ReporterPb', fakeReporterPb);
+	const fakeReporterPb = new Proxy(() => {}, {
+		construct() {
+			return fakeReporterPbInstance;
+		},
+		get(...args) {
+			const [, prop] = args;
+			debugLog(`ReporterPb.${prop} called with`, args);
+			return () => {};
+		},
+	});
+	defineReadonlyGlobal("ReporterPb", fakeReporterPb);
 
-    Object.defineProperty(unsafeWindow, '__biliUserFp__', {
-        get() {
-            return {
-                init() {},
-                queryUserLog() {
-                    return [];
-                },
-            };
-        },
-        set() {},
-    });
-    Object.defineProperty(unsafeWindow, '__USER_FP_CONFIG__', {
-        get() {
-            return undefined;
-        },
-        set() {},
-    });
-    Object.defineProperty(unsafeWindow, '__MIRROR_CONFIG__', {
-        get() {
-            return undefined;
-        },
-        set() {},
-    });
+	Object.defineProperty(unsafeWindow, "__biliUserFp__", {
+		get() {
+			return {
+				init() {},
+				queryUserLog() {
+					return [];
+				},
+			};
+		},
+		set() {},
+	});
+	Object.defineProperty(unsafeWindow, "__USER_FP_CONFIG__", {
+		get() {
+			return undefined;
+		},
+		set() {},
+	});
+	Object.defineProperty(unsafeWindow, "__MIRROR_CONFIG__", {
+		get() {
+			return undefined;
+		},
+		set() {},
+	});
 })();
 
-function debugLog() {
-    if (unsafeWindow.__MBGA_DEBUG__) console.log.apply(this, arguments);
+function debugLog(...args) {
+	if (unsafeWindow.__MBGA_DEBUG__) console.log(...args);
 }

--- a/scripts/BiliTab.user.js
+++ b/scripts/BiliTab.user.js
@@ -17,181 +17,177 @@
 // @grant        GM_deleteValue
 // @grant        GM_listValues
 // ==/UserScript==
-'use strict';
 
-const MENU_VALUE_PREFIX = 'bool_menu_value_for_';
-const MENU_ID_LIST_KEY = 'bool_menu_id_list';
-const PROCESSED_ATTR = 'x-bili-tab-processed';
-const ACTIVE_CLASS = 'x-bili-tab-active';
+const MENU_VALUE_PREFIX = "bool_menu_value_for_";
+const MENU_ID_LIST_KEY = "bool_menu_id_list";
+const PROCESSED_ATTR = "x-bili-tab-processed";
+const ACTIVE_CLASS = "x-bili-tab-active";
 const SCRIPT_NAME = GM_info.script.name;
 
 class Page {
-    constructor(object) {
-        this.name = object.name;
-        this.key = object.key;
-        this.selector = object.selector;
-        this.page_match = object.page_match;
-        this.default_enable = object.default_enable;
-    }
+	constructor(object) {
+		this.name = object.name;
+		this.key = object.key;
+		this.selector = object.selector;
+		this.page_match = object.page_match;
+		this.default_enable = object.default_enable;
+	}
 
-    refresh_menu() {
-        const menu_value_key = MENU_VALUE_PREFIX + this.key;
+	refresh_menu() {
+		const menu_value_key = MENU_VALUE_PREFIX + this.key;
 
-        const enabled = this.enabled();
+		const enabled = this.enabled();
 
-        const menu_icon = enabled ? '✅' : '❌';
-        const menu_name = `${menu_icon} ${this.name} 点击切换`;
-        registerMenuCommand(menu_name, () => {
-            GM_setValue(menu_value_key, !enabled);
-            refresh_menus();
-        });
-    }
+		const menu_icon = enabled ? "✅" : "❌";
+		const menu_name = `${menu_icon} ${this.name} 点击切换`;
+		registerMenuCommand(menu_name, () => {
+			GM_setValue(menu_value_key, !enabled);
+			refresh_menus();
+		});
+	}
 
-    attach() {
-        const url = new URL(window.location.href);
-        if (!this.page_match(url)) {
-            return;
-        }
-        this.on_page(); // 首次进入页面时执行一次
-        setInterval(this.on_page.bind(this), 500);
-    }
+	attach() {
+		const url = new URL(window.location.href);
+		if (!this.page_match(url)) {
+			return;
+		}
+		this.on_page(); // 首次进入页面时执行一次
+		setInterval(this.on_page.bind(this), 500);
+	}
 
-    on_page() {
-        const elements = document.querySelectorAll(this.selector);
-        for (const element of elements) {
-            set_background_click(element, this.key, this.default_enable);
-        }
-        if (elements.length > 0) {
-            console.log(`[${SCRIPT_NAME}] ${elements.length} 个链接已处理`);
-        }
-    }
+	on_page() {
+		const elements = document.querySelectorAll(this.selector);
+		for (const element of elements) {
+			set_background_click(element, this.key, this.default_enable);
+		}
+		if (elements.length > 0) {
+			console.log(`[${SCRIPT_NAME}] ${elements.length} 个链接已处理`);
+		}
+	}
 
-    enabled() {
-        return GM_getValue(MENU_VALUE_PREFIX + this.key, this.default_enable);
-    }
+	enabled() {
+		return GM_getValue(MENU_VALUE_PREFIX + this.key, this.default_enable);
+	}
 }
 
 const PAGES = [
-    new Page({
-        name: 'B 站首页',
-        key: 'bili_home',
-        selector: `div.bili-video-card a[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
-        page_match: (url) =>
-            url.host === 'www.bilibili.com' && url.pathname === '/',
-        default_enable: true,
-    }),
-    new Page({
-        name: 'B 站动态',
-        key: 'bili_activity',
-        selector: `a.bili-dyn-card-video[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
-        page_match: (url) => url.host === 't.bilibili.com',
-        default_enable: true,
-    }),
-    new Page({
-        name: 'B 站空间页',
-        key: 'bili_space',
-        selector: `a.cover[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
-        page_match: (url) => url.host === 'space.bilibili.com',
-        default_enable: true,
-    }),
+	new Page({
+		name: "B 站首页",
+		key: "bili_home",
+		selector: `div.bili-video-card a[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
+		page_match: (url) =>
+			url.host === "www.bilibili.com" && url.pathname === "/",
+		default_enable: true,
+	}),
+	new Page({
+		name: "B 站动态",
+		key: "bili_activity",
+		selector: `a.bili-dyn-card-video[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
+		page_match: (url) => url.host === "t.bilibili.com",
+		default_enable: true,
+	}),
+	new Page({
+		name: "B 站空间页",
+		key: "bili_space",
+		selector: `a.cover[href*="//www.bilibili.com/video/"]:not([${PROCESSED_ATTR}="true"])`,
+		page_match: (url) => url.host === "space.bilibili.com",
+		default_enable: true,
+	}),
 ];
 
 function refresh_menus() {
-    cleanAllMenu();
-    // TODO: 现有菜单点击开关的体验不是很好，切换成点击菜单时弹出对话框选择开关
-    for (const page of PAGES) {
-        page.refresh_menu();
-    }
+	cleanAllMenu();
+	// TODO: 现有菜单点击开关的体验不是很好，切换成点击菜单时弹出对话框选择开关
+	for (const page of PAGES) {
+		page.refresh_menu();
+	}
 
-    registerMenuCommand('🗑️重置所有设置', () => {
-        cleanAllMenu();
-        for (const key of GM_listValues()) {
-            GM_deleteValue(key);
-        }
-        refresh_menus();
-    });
+	registerMenuCommand("🗑️重置所有设置", () => {
+		cleanAllMenu();
+		for (const key of GM_listValues()) {
+			GM_deleteValue(key);
+		}
+		refresh_menus();
+	});
 }
 
 function set_background_click(old_element, page_name, default_enable) {
-    const new_element = old_element.cloneNode(false);
-    for (const child of old_element.childNodes) {
-        // 避免影响子元素的事件绑定
-        new_element.appendChild(child);
-    }
-    old_element.parentNode.replaceChild(new_element, old_element);
+	const new_element = old_element.cloneNode(false);
+	for (const child of old_element.childNodes) {
+		// 避免影响子元素的事件绑定
+		new_element.appendChild(child);
+	}
+	old_element.parentNode.replaceChild(new_element, old_element);
 
-    new_element.setAttribute('target', '_blank');
-    new_element.addEventListener('click', (event) => {
-        event.preventDefault();
+	new_element.setAttribute("target", "_blank");
+	new_element.addEventListener("click", (event) => {
+		event.preventDefault();
 
-        // 增加点击后的交互效果，因为不够精通 CSS，所以靠简单的 定时器 + class 来实现
-        new_element.classList.add(ACTIVE_CLASS);
-        setTimeout(() => new_element.classList.remove(ACTIVE_CLASS), 50);
+		// 增加点击后的交互效果，因为不够精通 CSS，所以靠简单的 定时器 + class 来实现
+		new_element.classList.add(ACTIVE_CLASS);
+		setTimeout(() => new_element.classList.remove(ACTIVE_CLASS), 50);
 
-        const tmp_ele = document.createElement('a');
-        tmp_ele.href = new_element.href;
-        tmp_ele.target = '_blank';
+		const tmp_ele = document.createElement("a");
+		tmp_ele.href = new_element.href;
+		tmp_ele.target = "_blank";
 
-        // 如果用户按下了 Ctrl 键或者 Command 键，默认行为是在后台标签页打开
-        let background_open = event.ctrlKey || event.metaKey;
+		// 如果用户按下了 Ctrl 键或者 Command 键，默认行为是在后台标签页打开
+		let background_open = event.ctrlKey || event.metaKey;
 
-        // 为了保证切换开关后对当前页面立即生效，这里直接读取开关值
-        const enable = GM_getValue(
-            MENU_VALUE_PREFIX + page_name,
-            default_enable,
-        );
-        if (enable) {
-            // 如果当前开关打开，则反转默认行为
-            background_open = !background_open;
-        }
+		// 为了保证切换开关后对当前页面立即生效，这里直接读取开关值
+		const enable = GM_getValue(MENU_VALUE_PREFIX + page_name, default_enable);
+		if (enable) {
+			// 如果当前开关打开，则反转默认行为
+			background_open = !background_open;
+		}
 
-        const mouse_event = new MouseEvent('click', {
-            ctrlKey: background_open, // for Windows and Linux
-            metaKey: background_open, // for Mac OS
-        });
-        tmp_ele.dispatchEvent(new MouseEvent('click', mouse_event));
-    });
-    new_element.setAttribute(PROCESSED_ATTR, 'true');
+		const mouse_event = new MouseEvent("click", {
+			ctrlKey: background_open, // for Windows and Linux
+			metaKey: background_open, // for Mac OS
+		});
+		tmp_ele.dispatchEvent(new MouseEvent("click", mouse_event));
+	});
+	new_element.setAttribute(PROCESSED_ATTR, "true");
 }
 
 function registerMenuCommand(name, callback, accessKey) {
-    const menu_id = GM_registerMenuCommand(name, callback, accessKey);
-    const current = GM_getValue(MENU_ID_LIST_KEY, []);
-    current.push(menu_id);
-    GM_setValue(MENU_ID_LIST_KEY, current);
+	const menu_id = GM_registerMenuCommand(name, callback, accessKey);
+	const current = GM_getValue(MENU_ID_LIST_KEY, []);
+	current.push(menu_id);
+	GM_setValue(MENU_ID_LIST_KEY, current);
 }
 
 function cleanAllMenu() {
-    const current = GM_getValue(MENU_ID_LIST_KEY, []);
-    for (const menu_id of current) {
-        GM_unregisterMenuCommand(menu_id);
-    }
-    GM_deleteValue(MENU_ID_LIST_KEY);
+	const current = GM_getValue(MENU_ID_LIST_KEY, []);
+	for (const menu_id of current) {
+		GM_unregisterMenuCommand(menu_id);
+	}
+	GM_deleteValue(MENU_ID_LIST_KEY);
 }
 
 function injectStyle() {
-    const style = document.createElement('style');
-    style.innerHTML = `
+	const style = document.createElement("style");
+	style.innerHTML = `
         .${ACTIVE_CLASS} {
             filter: brightness(95%);
         }
     `;
-    document.head.appendChild(style);
+	document.head.appendChild(style);
 }
 
 function main() {
-    injectStyle();
-    refresh_menus();
-    const url = new URL(window.location.href);
-    for (const page of PAGES) {
-        if (page.page_match(url)) {
-            page.attach();
-        }
-    }
+	injectStyle();
+	refresh_menus();
+	const url = new URL(window.location.href);
+	for (const page of PAGES) {
+		if (page.page_match(url)) {
+			page.attach();
+		}
+	}
 }
 
 try {
-    main();
+	main();
 } catch (e) {
-    console.error(`[${SCRIPT_NAME}] ${e}`);
+	console.error(`[${SCRIPT_NAME}] ${e}`);
 }

--- a/scripts/CodexUsageRemainingTime.user.js
+++ b/scripts/CodexUsageRemainingTime.user.js
@@ -9,15 +9,14 @@
 // @version      20260525
 // @license      MIT
 // ==/UserScript==
-'use strict';
 
-const SCRIPT_NAME = 'CodexUsageRemainingTime';
-const RESET_PREFIX = '重置时间：';
-const RATE_LIMIT_API_URL = '/backend-api/wham/usage';
-const TIME_MARKER_ATTR = 'data-codex-usage-time-marker';
-const WEEK_SEGMENTS_ATTR = 'data-codex-usage-week-segments';
-const MARKER_COLOR = 'rgb(217, 119, 6)';
-const SEGMENT_COLOR = 'rgba(107, 114, 128, 0.42)';
+const SCRIPT_NAME = "CodexUsageRemainingTime";
+const RESET_PREFIX = "重置时间：";
+const RATE_LIMIT_API_URL = "/backend-api/wham/usage";
+const TIME_MARKER_ATTR = "data-codex-usage-time-marker";
+const WEEK_SEGMENTS_ATTR = "data-codex-usage-week-segments";
+const MARKER_COLOR = "rgb(217, 119, 6)";
+const SEGMENT_COLOR = "rgba(107, 114, 128, 0.42)";
 const UPDATE_INTERVAL_MS = 30 * 1000;
 const USAGE_CACHE_MS = 5 * 60 * 1000;
 const WINDOW_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
@@ -29,454 +28,450 @@ let usageFetchPromise = null;
 let usageFetchFailed = false;
 
 function normalizeText(text) {
-    return (text || '').replace(/\s+/g, ' ').trim();
+	return (text || "").replace(/\s+/g, " ").trim();
 }
 
 function parseResetDate(resetText, now) {
-    const raw = normalizeText(resetText);
-    if (!raw.startsWith(RESET_PREFIX)) {
-        return null;
-    }
+	const raw = normalizeText(resetText);
+	if (!raw.startsWith(RESET_PREFIX)) {
+		return null;
+	}
 
-    const value = raw.slice(RESET_PREFIX.length).trim();
-    if (!value) {
-        return null;
-    }
+	const value = raw.slice(RESET_PREFIX.length).trim();
+	if (!value) {
+		return null;
+	}
 
-    const fullMatch = value.match(
-        /^(\d{4})年(\d{1,2})月(\d{1,2})日\s+(\d{1,2}):(\d{2})$/,
-    );
-    if (fullMatch) {
-        return new Date(
-            Number(fullMatch[1]),
-            Number(fullMatch[2]) - 1,
-            Number(fullMatch[3]),
-            Number(fullMatch[4]),
-            Number(fullMatch[5]),
-            0,
-            0,
-        );
-    }
+	const fullMatch = value.match(
+		/^(\d{4})年(\d{1,2})月(\d{1,2})日\s+(\d{1,2}):(\d{2})$/,
+	);
+	if (fullMatch) {
+		return new Date(
+			Number(fullMatch[1]),
+			Number(fullMatch[2]) - 1,
+			Number(fullMatch[3]),
+			Number(fullMatch[4]),
+			Number(fullMatch[5]),
+			0,
+			0,
+		);
+	}
 
-    const shortMatch = value.match(/^(\d{1,2}):(\d{2})$/);
-    if (shortMatch) {
-        const candidate = new Date(
-            now.getFullYear(),
-            now.getMonth(),
-            now.getDate(),
-            Number(shortMatch[1]),
-            Number(shortMatch[2]),
-            0,
-            0,
-        );
-        if (candidate.getTime() <= now.getTime()) {
-            candidate.setDate(candidate.getDate() + 1);
-        }
-        return candidate;
-    }
+	const shortMatch = value.match(/^(\d{1,2}):(\d{2})$/);
+	if (shortMatch) {
+		const candidate = new Date(
+			now.getFullYear(),
+			now.getMonth(),
+			now.getDate(),
+			Number(shortMatch[1]),
+			Number(shortMatch[2]),
+			0,
+			0,
+		);
+		if (candidate.getTime() <= now.getTime()) {
+			candidate.setDate(candidate.getDate() + 1);
+		}
+		return candidate;
+	}
 
-    return null;
+	return null;
 }
 
 function clampPercent(value) {
-    return Math.max(0, Math.min(100, value));
+	return Math.max(0, Math.min(100, value));
 }
 
 function getWindowMs(title) {
-    if (title.includes('每周')) {
-        return WINDOW_WEEK_MS;
-    }
-    return null;
+	if (title.includes("每周")) {
+		return WINDOW_WEEK_MS;
+	}
+	return null;
 }
 
 function isApproximately(value, target) {
-    return (
-        typeof value === 'number' &&
-        Number.isFinite(value) &&
-        value > 0 &&
-        Math.abs(value - target) <= target * 0.05
-    );
+	return (
+		typeof value === "number" &&
+		Number.isFinite(value) &&
+		value > 0 &&
+		Math.abs(value - target) <= target * 0.05
+	);
 }
 
 function getWeeklyLimitName(title) {
-    const normalizedTitle = normalizeText(title);
-    const zhSuffix = '每周使用限额';
-    if (normalizedTitle.endsWith(zhSuffix)) {
-        return normalizedTitle.slice(0, -zhSuffix.length).trim();
-    }
+	const normalizedTitle = normalizeText(title);
+	const zhSuffix = "每周使用限额";
+	if (normalizedTitle.endsWith(zhSuffix)) {
+		return normalizedTitle.slice(0, -zhSuffix.length).trim();
+	}
 
-    const enSuffix = 'Weekly usage limit';
-    if (normalizedTitle.endsWith(enSuffix)) {
-        return normalizedTitle.slice(0, -enSuffix.length).trim();
-    }
+	const enSuffix = "Weekly usage limit";
+	if (normalizedTitle.endsWith(enSuffix)) {
+		return normalizedTitle.slice(0, -enSuffix.length).trim();
+	}
 
-    return null;
+	return null;
 }
 
 function normalizeLimitName(value) {
-    return normalizeText(value).toLowerCase();
+	return normalizeText(value).toLowerCase();
 }
 
 function getArticleTitle(article) {
-    const titleNode = article.querySelector('p');
-    return normalizeText(titleNode?.textContent);
+	const titleNode = article.querySelector("p");
+	return normalizeText(titleNode?.textContent);
 }
 
 function findResetElement(article) {
-    const elements = Array.from(article.querySelectorAll('*')).filter(
-        (element) =>
-            normalizeText(element.textContent).startsWith(RESET_PREFIX),
-    );
+	const elements = Array.from(article.querySelectorAll("*")).filter((element) =>
+		normalizeText(element.textContent).startsWith(RESET_PREFIX),
+	);
 
-    return (
-        elements.find(
-            (element) =>
-                !Array.from(element.children).some((child) =>
-                    normalizeText(child.textContent).startsWith(RESET_PREFIX),
-                ),
-        ) || null
-    );
+	return (
+		elements.find(
+			(element) =>
+				!Array.from(element.children).some((child) =>
+					normalizeText(child.textContent).startsWith(RESET_PREFIX),
+				),
+		) || null
+	);
 }
 
 function extractResetText(resetElement) {
-    for (const child of resetElement.childNodes) {
-        if (child.nodeType === Node.TEXT_NODE) {
-            const text = normalizeText(child.textContent);
-            if (text.startsWith(RESET_PREFIX)) {
-                return text;
-            }
-            continue;
-        }
+	for (const child of resetElement.childNodes) {
+		if (child.nodeType === Node.TEXT_NODE) {
+			const text = normalizeText(child.textContent);
+			if (text.startsWith(RESET_PREFIX)) {
+				return text;
+			}
+			continue;
+		}
 
-        if (child.nodeType !== Node.ELEMENT_NODE) {
-            continue;
-        }
-        const text = normalizeText(child.textContent);
-        if (text.startsWith(RESET_PREFIX)) {
-            return text;
-        }
-    }
+		if (child.nodeType !== Node.ELEMENT_NODE) {
+			continue;
+		}
+		const text = normalizeText(child.textContent);
+		if (text.startsWith(RESET_PREFIX)) {
+			return text;
+		}
+	}
 
-    const fallback = normalizeText(resetElement.textContent).match(
-        /重置时间：\s*(\d{4}年\d{1,2}月\d{1,2}日\s+\d{1,2}:\d{2}|\d{1,2}:\d{2})/,
-    );
-    return fallback ? `${RESET_PREFIX}${fallback[1]}` : '';
+	const fallback = normalizeText(resetElement.textContent).match(
+		/重置时间：\s*(\d{4}年\d{1,2}月\d{1,2}日\s+\d{1,2}:\d{2}|\d{1,2}:\d{2})/,
+	);
+	return fallback ? `${RESET_PREFIX}${fallback[1]}` : "";
 }
 
 function findProgressHost(article) {
-    return (
-        Array.from(article.querySelectorAll('div')).find(
-            (element) =>
-                element.classList.contains('relative') &&
-                element.classList.contains('w-full'),
-        ) || null
-    );
+	return (
+		Array.from(article.querySelectorAll("div")).find(
+			(element) =>
+				element.classList.contains("relative") &&
+				element.classList.contains("w-full"),
+		) || null
+	);
 }
 
 function getWindowResetAtMs(windowData, fetchedAtMs) {
-    const resetAfterSeconds = Number(windowData?.reset_after_seconds);
-    if (!Number.isFinite(resetAfterSeconds) || resetAfterSeconds < 0) {
-        return null;
-    }
-    return fetchedAtMs + resetAfterSeconds * 1000;
+	const resetAfterSeconds = Number(windowData?.reset_after_seconds);
+	if (!Number.isFinite(resetAfterSeconds) || resetAfterSeconds < 0) {
+		return null;
+	}
+	return fetchedAtMs + resetAfterSeconds * 1000;
 }
 
 function collectWeeklyWindows(usageData, fetchedAtMs) {
-    const windows = [];
-    const addWindow = (limitName, windowData) => {
-        if (
-            !windowData ||
-            !isApproximately(
-                Number(windowData.limit_window_seconds),
-                WINDOW_WEEK_SECONDS,
-            )
-        ) {
-            return;
-        }
+	const windows = [];
+	const addWindow = (limitName, windowData) => {
+		if (
+			!windowData ||
+			!isApproximately(
+				Number(windowData.limit_window_seconds),
+				WINDOW_WEEK_SECONDS,
+			)
+		) {
+			return;
+		}
 
-        const resetAtMs = getWindowResetAtMs(windowData, fetchedAtMs);
-        if (resetAtMs === null) {
-            return;
-        }
+		const resetAtMs = getWindowResetAtMs(windowData, fetchedAtMs);
+		if (resetAtMs === null) {
+			return;
+		}
 
-        windows.push({
-            limitName: normalizeLimitName(limitName),
-            resetAtMs,
-            windowMs: WINDOW_WEEK_MS,
-        });
-    };
+		windows.push({
+			limitName: normalizeLimitName(limitName),
+			resetAtMs,
+			windowMs: WINDOW_WEEK_MS,
+		});
+	};
 
-    addWindow('', usageData?.rate_limit?.primary_window);
-    addWindow('', usageData?.rate_limit?.secondary_window);
+	addWindow("", usageData?.rate_limit?.primary_window);
+	addWindow("", usageData?.rate_limit?.secondary_window);
 
-    for (const additionalLimit of usageData?.additional_rate_limits || []) {
-        addWindow(
-            additionalLimit?.limit_name || '',
-            additionalLimit?.rate_limit?.primary_window,
-        );
-        addWindow(
-            additionalLimit?.limit_name || '',
-            additionalLimit?.rate_limit?.secondary_window,
-        );
-    }
+	for (const additionalLimit of usageData?.additional_rate_limits || []) {
+		addWindow(
+			additionalLimit?.limit_name || "",
+			additionalLimit?.rate_limit?.primary_window,
+		);
+		addWindow(
+			additionalLimit?.limit_name || "",
+			additionalLimit?.rate_limit?.secondary_window,
+		);
+	}
 
-    return windows;
+	return windows;
 }
 
 async function fetchUsageSnapshot() {
-    const nowMs = Date.now();
-    if (usageSnapshot && nowMs - usageSnapshot.fetchedAtMs < USAGE_CACHE_MS) {
-        return usageSnapshot;
-    }
+	const nowMs = Date.now();
+	if (usageSnapshot && nowMs - usageSnapshot.fetchedAtMs < USAGE_CACHE_MS) {
+		return usageSnapshot;
+	}
 
-    if (usageFetchPromise) {
-        return usageFetchPromise;
-    }
+	if (usageFetchPromise) {
+		return usageFetchPromise;
+	}
 
-    usageFetchPromise = fetch(RATE_LIMIT_API_URL, {
-        credentials: 'include',
-        headers: {
-            accept: 'application/json',
-        },
-    })
-        .then((response) => {
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            return response.json();
-        })
-        .then((usageData) => {
-            const fetchedAtMs = Date.now();
-            usageSnapshot = {
-                fetchedAtMs,
-                weeklyWindows: collectWeeklyWindows(usageData, fetchedAtMs),
-            };
-            usageFetchFailed = false;
-            return usageSnapshot;
-        })
-        .catch((error) => {
-            usageSnapshot = null;
-            if (!usageFetchFailed) {
-                usageFetchFailed = true;
-                console.warn(
-                    `[${SCRIPT_NAME}] Failed to fetch usage data`,
-                    error,
-                );
-            }
-            return null;
-        })
-        .finally(() => {
-            usageFetchPromise = null;
-        });
+	usageFetchPromise = fetch(RATE_LIMIT_API_URL, {
+		credentials: "include",
+		headers: {
+			accept: "application/json",
+		},
+	})
+		.then((response) => {
+			if (!response.ok) {
+				throw new Error(`HTTP ${response.status}`);
+			}
+			return response.json();
+		})
+		.then((usageData) => {
+			const fetchedAtMs = Date.now();
+			usageSnapshot = {
+				fetchedAtMs,
+				weeklyWindows: collectWeeklyWindows(usageData, fetchedAtMs),
+			};
+			usageFetchFailed = false;
+			return usageSnapshot;
+		})
+		.catch((error) => {
+			usageSnapshot = null;
+			if (!usageFetchFailed) {
+				usageFetchFailed = true;
+				console.warn(`[${SCRIPT_NAME}] Failed to fetch usage data`, error);
+			}
+			return null;
+		})
+		.finally(() => {
+			usageFetchPromise = null;
+		});
 
-    return usageFetchPromise;
+	return usageFetchPromise;
 }
 
 function findWeeklyWindow(limitWindows, title) {
-    const limitName = getWeeklyLimitName(title);
-    if (limitName === null) {
-        return null;
-    }
+	const limitName = getWeeklyLimitName(title);
+	if (limitName === null) {
+		return null;
+	}
 
-    const normalizedLimitName = normalizeLimitName(limitName);
-    return (
-        limitWindows.find(
-            (windowData) => windowData.limitName === normalizedLimitName,
-        ) || null
-    );
+	const normalizedLimitName = normalizeLimitName(limitName);
+	return (
+		limitWindows.find(
+			(windowData) => windowData.limitName === normalizedLimitName,
+		) || null
+	);
 }
 
 function setStyleValue(element, property, value) {
-    if (element.style[property] !== value) {
-        element.style[property] = value;
-    }
+	if (element.style[property] !== value) {
+		element.style[property] = value;
+	}
 }
 
 function updateWeeklySegments(progressHost) {
-    let segments = progressHost.querySelector(
-        `span[${WEEK_SEGMENTS_ATTR}="true"]`,
-    );
-    if (!segments) {
-        segments = document.createElement('span');
-        segments.setAttribute(WEEK_SEGMENTS_ATTR, 'true');
-        for (let day = 1; day < WEEK_DAYS; day += 1) {
-            const divider = document.createElement('span');
-            divider.style.position = 'absolute';
-            divider.style.top = '-3px';
-            divider.style.bottom = '-3px';
-            divider.style.left = `${(day / WEEK_DAYS) * 100}%`;
-            divider.style.width = '1px';
-            divider.style.transform = 'translateX(-1px)';
-            divider.style.backgroundColor = SEGMENT_COLOR;
-            divider.style.boxShadow = '0 0 0 1px rgba(255, 255, 255, 0.5)';
-            segments.appendChild(divider);
-        }
-        progressHost.appendChild(segments);
-    }
+	let segments = progressHost.querySelector(
+		`span[${WEEK_SEGMENTS_ATTR}="true"]`,
+	);
+	if (!segments) {
+		segments = document.createElement("span");
+		segments.setAttribute(WEEK_SEGMENTS_ATTR, "true");
+		for (let day = 1; day < WEEK_DAYS; day += 1) {
+			const divider = document.createElement("span");
+			divider.style.position = "absolute";
+			divider.style.top = "-3px";
+			divider.style.bottom = "-3px";
+			divider.style.left = `${(day / WEEK_DAYS) * 100}%`;
+			divider.style.width = "1px";
+			divider.style.transform = "translateX(-1px)";
+			divider.style.backgroundColor = SEGMENT_COLOR;
+			divider.style.boxShadow = "0 0 0 1px rgba(255, 255, 255, 0.5)";
+			segments.appendChild(divider);
+		}
+		progressHost.appendChild(segments);
+	}
 
-    setStyleValue(segments, 'position', 'absolute');
-    setStyleValue(segments, 'inset', '0');
-    setStyleValue(segments, 'pointerEvents', 'none');
+	setStyleValue(segments, "position", "absolute");
+	setStyleValue(segments, "inset", "0");
+	setStyleValue(segments, "pointerEvents", "none");
 }
 
 function getWeekDayIndex(resetDate, now) {
-    const windowStartMs = resetDate.getTime() - WINDOW_WEEK_MS;
-    const elapsedMs = now.getTime() - windowStartMs;
-    const rawIndex = Math.floor((elapsedMs / WINDOW_WEEK_MS) * WEEK_DAYS);
-    return Math.max(0, Math.min(WEEK_DAYS - 1, rawIndex));
+	const windowStartMs = resetDate.getTime() - WINDOW_WEEK_MS;
+	const elapsedMs = now.getTime() - windowStartMs;
+	const rawIndex = Math.floor((elapsedMs / WINDOW_WEEK_MS) * WEEK_DAYS);
+	return Math.max(0, Math.min(WEEK_DAYS - 1, rawIndex));
 }
 
 function updateWeeklyDayMarker(
-    progressHost,
-    resetDate,
-    now,
-    timeRemainingPercent,
+	progressHost,
+	resetDate,
+	now,
+	timeRemainingPercent,
 ) {
-    updateWeeklySegments(progressHost);
+	updateWeeklySegments(progressHost);
 
-    let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
-    if (!marker) {
-        marker = document.createElement('span');
-        marker.setAttribute(TIME_MARKER_ATTR, 'true');
-        progressHost.appendChild(marker);
-    }
+	let marker = progressHost.querySelector(`span[${TIME_MARKER_ATTR}="true"]`);
+	if (!marker) {
+		marker = document.createElement("span");
+		marker.setAttribute(TIME_MARKER_ATTR, "true");
+		progressHost.appendChild(marker);
+	}
 
-    const dayIndex = getWeekDayIndex(resetDate, now);
-    const left = `${clampPercent(timeRemainingPercent)}%`;
-    const title = `每周窗口：当前第 ${dayIndex + 1} 天 / 共 ${WEEK_DAYS} 天`;
-    setStyleValue(marker, 'position', 'absolute');
-    setStyleValue(marker, 'top', 'calc(100% + 3px)');
-    setStyleValue(marker, 'bottom', '');
-    setStyleValue(marker, 'left', left);
-    setStyleValue(marker, 'width', '8px');
-    setStyleValue(marker, 'height', '8px');
-    setStyleValue(marker, 'borderLeft', '');
-    setStyleValue(marker, 'borderRight', '');
-    setStyleValue(marker, 'borderBottom', '');
-    setStyleValue(marker, 'borderRadius', '999px');
-    setStyleValue(marker, 'pointerEvents', 'none');
-    setStyleValue(marker, 'transform', 'translateX(-4px)');
-    setStyleValue(marker, 'backgroundColor', MARKER_COLOR);
-    setStyleValue(
-        marker,
-        'boxShadow',
-        '0 0 0 2px rgba(255, 255, 255, 0.95), 0 1px 3px rgba(0, 0, 0, 0.18)',
-    );
-    if (marker.title !== title) {
-        marker.title = title;
-    }
+	const dayIndex = getWeekDayIndex(resetDate, now);
+	const left = `${clampPercent(timeRemainingPercent)}%`;
+	const title = `每周窗口：当前第 ${dayIndex + 1} 天 / 共 ${WEEK_DAYS} 天`;
+	setStyleValue(marker, "position", "absolute");
+	setStyleValue(marker, "top", "calc(100% + 3px)");
+	setStyleValue(marker, "bottom", "");
+	setStyleValue(marker, "left", left);
+	setStyleValue(marker, "width", "8px");
+	setStyleValue(marker, "height", "8px");
+	setStyleValue(marker, "borderLeft", "");
+	setStyleValue(marker, "borderRight", "");
+	setStyleValue(marker, "borderBottom", "");
+	setStyleValue(marker, "borderRadius", "999px");
+	setStyleValue(marker, "pointerEvents", "none");
+	setStyleValue(marker, "transform", "translateX(-4px)");
+	setStyleValue(marker, "backgroundColor", MARKER_COLOR);
+	setStyleValue(
+		marker,
+		"boxShadow",
+		"0 0 0 2px rgba(255, 255, 255, 0.95), 0 1px 3px rgba(0, 0, 0, 0.18)",
+	);
+	if (marker.title !== title) {
+		marker.title = title;
+	}
 }
 
 function updateArticleFromApi(article, now, limitWindows) {
-    const title = getArticleTitle(article);
-    const weeklyWindow = findWeeklyWindow(limitWindows, title);
-    if (!weeklyWindow) {
-        return false;
-    }
+	const title = getArticleTitle(article);
+	const weeklyWindow = findWeeklyWindow(limitWindows, title);
+	if (!weeklyWindow) {
+		return false;
+	}
 
-    const remainingMs = weeklyWindow.resetAtMs - now.getTime();
-    const timeRemainingPercent = clampPercent(
-        (remainingMs / weeklyWindow.windowMs) * 100,
-    );
+	const remainingMs = weeklyWindow.resetAtMs - now.getTime();
+	const timeRemainingPercent = clampPercent(
+		(remainingMs / weeklyWindow.windowMs) * 100,
+	);
 
-    const progressHost = findProgressHost(article);
-    if (!progressHost) {
-        return false;
-    }
+	const progressHost = findProgressHost(article);
+	if (!progressHost) {
+		return false;
+	}
 
-    updateWeeklyDayMarker(
-        progressHost,
-        new Date(weeklyWindow.resetAtMs),
-        now,
-        timeRemainingPercent,
-    );
-    return true;
+	updateWeeklyDayMarker(
+		progressHost,
+		new Date(weeklyWindow.resetAtMs),
+		now,
+		timeRemainingPercent,
+	);
+	return true;
 }
 
 function updateArticleFromResetText(article, now) {
-    const title = getArticleTitle(article);
-    const windowMs = getWindowMs(title);
-    if (!windowMs) {
-        return;
-    }
+	const title = getArticleTitle(article);
+	const windowMs = getWindowMs(title);
+	if (!windowMs) {
+		return;
+	}
 
-    const resetElement = findResetElement(article);
-    if (!resetElement) {
-        return;
-    }
+	const resetElement = findResetElement(article);
+	if (!resetElement) {
+		return;
+	}
 
-    const resetDate = parseResetDate(extractResetText(resetElement), now);
-    if (!resetDate) {
-        return;
-    }
+	const resetDate = parseResetDate(extractResetText(resetElement), now);
+	if (!resetDate) {
+		return;
+	}
 
-    const remainingMs = resetDate.getTime() - now.getTime();
-    const timeRemainingPercent = clampPercent((remainingMs / windowMs) * 100);
+	const remainingMs = resetDate.getTime() - now.getTime();
+	const timeRemainingPercent = clampPercent((remainingMs / windowMs) * 100);
 
-    const progressHost = findProgressHost(article);
-    if (!progressHost) {
-        return;
-    }
+	const progressHost = findProgressHost(article);
+	if (!progressHost) {
+		return;
+	}
 
-    updateWeeklyDayMarker(progressHost, resetDate, now, timeRemainingPercent);
+	updateWeeklyDayMarker(progressHost, resetDate, now, timeRemainingPercent);
 }
 
 async function updateAllCardsAsync() {
-    const now = new Date();
-    const snapshot = await fetchUsageSnapshot();
-    const weeklyWindows = snapshot?.weeklyWindows || [];
+	const now = new Date();
+	const snapshot = await fetchUsageSnapshot();
+	const weeklyWindows = snapshot?.weeklyWindows || [];
 
-    for (const article of document.querySelectorAll('article')) {
-        if (
-            weeklyWindows.length > 0 &&
-            updateArticleFromApi(article, now, weeklyWindows)
-        ) {
-            continue;
-        }
+	for (const article of document.querySelectorAll("article")) {
+		if (
+			weeklyWindows.length > 0 &&
+			updateArticleFromApi(article, now, weeklyWindows)
+		) {
+			continue;
+		}
 
-        updateArticleFromResetText(article, now);
-    }
+		updateArticleFromResetText(article, now);
+	}
 }
 
 function updateAllCards() {
-    updateAllCardsAsync().catch((error) => {
-        console.error(`[${SCRIPT_NAME}]`, error);
-    });
+	updateAllCardsAsync().catch((error) => {
+		console.error(`[${SCRIPT_NAME}]`, error);
+	});
 }
 
 function scheduleUpdateAllCards() {
-    if (updateScheduled) {
-        return;
-    }
+	if (updateScheduled) {
+		return;
+	}
 
-    updateScheduled = true;
-    requestAnimationFrame(() => {
-        updateScheduled = false;
-        updateAllCards();
-    });
+	updateScheduled = true;
+	requestAnimationFrame(() => {
+		updateScheduled = false;
+		updateAllCards();
+	});
 }
 
 function observeAndUpdate() {
-    updateAllCards();
+	updateAllCards();
 
-    const observer = new MutationObserver(() => {
-        scheduleUpdateAllCards();
-    });
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-        characterData: true,
-    });
+	const observer = new MutationObserver(() => {
+		scheduleUpdateAllCards();
+	});
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+		characterData: true,
+	});
 
-    setInterval(updateAllCards, UPDATE_INTERVAL_MS);
+	setInterval(updateAllCards, UPDATE_INTERVAL_MS);
 }
 
 function main() {
-    observeAndUpdate();
+	observeAndUpdate();
 }
 
 try {
-    main();
+	main();
 } catch (error) {
-    console.error(`[${SCRIPT_NAME}]`, error);
+	console.error(`[${SCRIPT_NAME}]`, error);
 }

--- a/scripts/GitHubDateNumeric.user.js
+++ b/scripts/GitHubDateNumeric.user.js
@@ -9,14 +9,13 @@
 // @version      20260426
 // @license      MIT
 // ==/UserScript==
-'use strict';
 
-const SCRIPT_NAME = 'GitHubDateNumeric';
-const RELATIVE_TIME_SELECTOR = 'relative-time[datetime]';
+const SCRIPT_NAME = "GitHubDateNumeric";
+const RELATIVE_TIME_SELECTOR = "relative-time[datetime]";
 const COMMIT_GROUP_TITLE_SELECTOR = '[data-testid="commit-group-title"]';
-const COMMIT_GROUP_PREFIX = 'Commits on ';
+const COMMIT_GROUP_PREFIX = "Commits on ";
 const RELATIVE_TIME_PATCHED = Symbol.for(
-    'GitHubDateNumeric.relativeTimePatched',
+	"GitHubDateNumeric.relativeTimePatched",
 );
 const MINUTE_MS = 60 * 1000;
 const HOUR_MS = 60 * MINUTE_MS;
@@ -24,256 +23,256 @@ const DAY_MS = 24 * HOUR_MS;
 const WEEK_MS = 7 * DAY_MS;
 
 function pad2(value) {
-    return String(value).padStart(2, '0');
+	return String(value).padStart(2, "0");
 }
 
 function formatUnit(value, singular, plural) {
-    return value === 1 ? `1 ${singular}` : `${value} ${plural}`;
+	return value === 1 ? `1 ${singular}` : `${value} ${plural}`;
 }
 
 function formatDate(date, now) {
-    const year = date.getFullYear();
-    const month = pad2(date.getMonth() + 1);
-    const day = pad2(date.getDate());
-    const currentYear = now.getFullYear();
-    return year === currentYear ? `${month}-${day}` : `${year}-${month}-${day}`;
+	const year = date.getFullYear();
+	const month = pad2(date.getMonth() + 1);
+	const day = pad2(date.getDate());
+	const currentYear = now.getFullYear();
+	return year === currentYear ? `${month}-${day}` : `${year}-${month}-${day}`;
 }
 
 function formatDateTime(date) {
-    const year = date.getFullYear();
-    const month = pad2(date.getMonth() + 1);
-    const day = pad2(date.getDate());
-    const hour = pad2(date.getHours());
-    const minute = pad2(date.getMinutes());
-    const second = pad2(date.getSeconds());
-    return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+	const year = date.getFullYear();
+	const month = pad2(date.getMonth() + 1);
+	const day = pad2(date.getDate());
+	const hour = pad2(date.getHours());
+	const minute = pad2(date.getMinutes());
+	const second = pad2(date.getSeconds());
+	return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
 }
 
 function formatRelative(deltaMs) {
-    const abs = Math.abs(deltaMs);
-    if (abs < MINUTE_MS) {
-        return 'just now';
-    }
-    if (abs < HOUR_MS) {
-        const mins = Math.floor(abs / MINUTE_MS);
-        const unit = formatUnit(mins, 'min', 'mins');
-        return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
-    }
-    if (abs < DAY_MS) {
-        const hours = Math.floor(abs / HOUR_MS);
-        const unit = formatUnit(hours, 'hour', 'hours');
-        return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
-    }
-    const days = Math.floor(abs / DAY_MS);
-    const unit = formatUnit(days, 'day', 'days');
-    return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
+	const abs = Math.abs(deltaMs);
+	if (abs < MINUTE_MS) {
+		return "just now";
+	}
+	if (abs < HOUR_MS) {
+		const mins = Math.floor(abs / MINUTE_MS);
+		const unit = formatUnit(mins, "min", "mins");
+		return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
+	}
+	if (abs < DAY_MS) {
+		const hours = Math.floor(abs / HOUR_MS);
+		const unit = formatUnit(hours, "hour", "hours");
+		return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
+	}
+	const days = Math.floor(abs / DAY_MS);
+	const unit = formatUnit(days, "day", "days");
+	return deltaMs >= 0 ? `${unit} ago` : `in ${unit}`;
 }
 
 function pickDisplay(date, now) {
-    const deltaMs = now.getTime() - date.getTime();
-    if (Math.abs(deltaMs) < WEEK_MS) {
-        return formatRelative(deltaMs);
-    }
-    return formatDate(date, now);
+	const deltaMs = now.getTime() - date.getTime();
+	if (Math.abs(deltaMs) < WEEK_MS) {
+		return formatRelative(deltaMs);
+	}
+	return formatDate(date, now);
 }
 
 function parseDatetime(node) {
-    const datetime = node.getAttribute('datetime');
-    if (!datetime) {
-        return null;
-    }
-    const date = new Date(datetime);
-    if (Number.isNaN(date.getTime())) {
-        return null;
-    }
-    return { date, datetime };
+	const datetime = node.getAttribute("datetime");
+	if (!datetime) {
+		return null;
+	}
+	const date = new Date(datetime);
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+	return { date, datetime };
 }
 
 function setRelativeTimeText(node, text) {
-    const target = node.shadowRoot;
-    if (target) {
-        const root = target.querySelector('[part="root"]');
-        if (root) {
-            root.textContent = text;
-            return;
-        }
-        target.textContent = text;
-        return;
-    }
-    node.textContent = text;
+	const target = node.shadowRoot;
+	if (target) {
+		const root = target.querySelector('[part="root"]');
+		if (root) {
+			root.textContent = text;
+			return;
+		}
+		target.textContent = text;
+		return;
+	}
+	node.textContent = text;
 }
 
 function getDatePrefix(node, text) {
-    const explicitPrefix = node.getAttribute('prefix');
-    if (explicitPrefix === '') {
-        return '';
-    }
-    if (explicitPrefix) {
-        return `${explicitPrefix.trim()} `;
-    }
-    return text.trim().startsWith('on ') ? 'on ' : '';
+	const explicitPrefix = node.getAttribute("prefix");
+	if (explicitPrefix === "") {
+		return "";
+	}
+	if (explicitPrefix) {
+		return `${explicitPrefix.trim()} `;
+	}
+	return text.trim().startsWith("on ") ? "on " : "";
 }
 
 function renderRelativeTime(node) {
-    const parsed = parseDatetime(node);
-    if (!parsed) {
-        return;
-    }
-    const now = new Date();
-    let display = pickDisplay(parsed.date, now);
-    const prefix = getDatePrefix(node, node.textContent || '');
-    if (Math.abs(now.getTime() - parsed.date.getTime()) >= WEEK_MS && prefix) {
-        display = `${prefix}${display}`;
-    }
-    node.setAttribute('title', formatDateTime(parsed.date));
-    setRelativeTimeText(node, display);
+	const parsed = parseDatetime(node);
+	if (!parsed) {
+		return;
+	}
+	const now = new Date();
+	let display = pickDisplay(parsed.date, now);
+	const prefix = getDatePrefix(node, node.textContent || "");
+	if (Math.abs(now.getTime() - parsed.date.getTime()) >= WEEK_MS && prefix) {
+		display = `${prefix}${display}`;
+	}
+	node.setAttribute("title", formatDateTime(parsed.date));
+	setRelativeTimeText(node, display);
 }
 
 function updateRelativeTimeNode(node) {
-    if (typeof node.update === 'function') {
-        node.update();
-        return;
-    }
-    renderRelativeTime(node);
+	if (typeof node.update === "function") {
+		node.update();
+		return;
+	}
+	renderRelativeTime(node);
 }
 
 function patchRelativeTimeElement(RelativeTimeElement) {
-    const proto = RelativeTimeElement && RelativeTimeElement.prototype;
-    if (!proto || proto[RELATIVE_TIME_PATCHED]) {
-        return;
-    }
-    const originalUpdate = proto.update;
-    if (typeof originalUpdate !== 'function') {
-        return;
-    }
-    Object.defineProperty(proto, RELATIVE_TIME_PATCHED, {
-        value: true,
-    });
-    proto.update = function update() {
-        originalUpdate.call(this);
-        renderRelativeTime(this);
-    };
+	const proto = RelativeTimeElement?.prototype;
+	if (!proto || proto[RELATIVE_TIME_PATCHED]) {
+		return;
+	}
+	const originalUpdate = proto.update;
+	if (typeof originalUpdate !== "function") {
+		return;
+	}
+	Object.defineProperty(proto, RELATIVE_TIME_PATCHED, {
+		value: true,
+	});
+	proto.update = function update() {
+		originalUpdate.call(this);
+		renderRelativeTime(this);
+	};
 }
 
 function setupRelativeTimeHook(schedule) {
-    window.customElements
-        .whenDefined('relative-time')
-        .then(() => {
-            patchRelativeTimeElement(
-                window.customElements.get('relative-time') ||
-                    window.RelativeTimeElement,
-            );
-            schedule();
-        })
-        .catch((error) => {
-            console.error(`[${SCRIPT_NAME}]`, error);
-        });
+	window.customElements
+		.whenDefined("relative-time")
+		.then(() => {
+			patchRelativeTimeElement(
+				window.customElements.get("relative-time") ||
+					window.RelativeTimeElement,
+			);
+			schedule();
+		})
+		.catch((error) => {
+			console.error(`[${SCRIPT_NAME}]`, error);
+		});
 }
 
 function parseCommitGroupTitle(node) {
-    const text = node.textContent;
-    if (!text || !text.startsWith(COMMIT_GROUP_PREFIX)) {
-        return null;
-    }
-    const dateText = text.slice(COMMIT_GROUP_PREFIX.length).trim();
-    const match = dateText.match(/^([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})$/);
-    if (!match) {
-        return null;
-    }
-    const [, monthName, dayText, yearText] = match;
-    const months = {
-        Jan: 1,
-        January: 1,
-        Feb: 2,
-        February: 2,
-        Mar: 3,
-        March: 3,
-        Apr: 4,
-        April: 4,
-        May: 5,
-        Jun: 6,
-        June: 6,
-        Jul: 7,
-        July: 7,
-        Aug: 8,
-        August: 8,
-        Sep: 9,
-        Sept: 9,
-        September: 9,
-        Oct: 10,
-        October: 10,
-        Nov: 11,
-        November: 11,
-        Dec: 12,
-        December: 12,
-    };
-    const month = months[monthName];
-    if (!month) {
-        return null;
-    }
-    const day = Number(dayText);
-    const year = Number(yearText);
-    if (!Number.isFinite(day) || !Number.isFinite(year)) {
-        return null;
-    }
-    return { year, month, day };
+	const text = node.textContent;
+	if (!text?.startsWith(COMMIT_GROUP_PREFIX)) {
+		return null;
+	}
+	const dateText = text.slice(COMMIT_GROUP_PREFIX.length).trim();
+	const match = dateText.match(/^([A-Za-z]+)\s+(\d{1,2}),\s+(\d{4})$/);
+	if (!match) {
+		return null;
+	}
+	const [, monthName, dayText, yearText] = match;
+	const months = {
+		Jan: 1,
+		January: 1,
+		Feb: 2,
+		February: 2,
+		Mar: 3,
+		March: 3,
+		Apr: 4,
+		April: 4,
+		May: 5,
+		Jun: 6,
+		June: 6,
+		Jul: 7,
+		July: 7,
+		Aug: 8,
+		August: 8,
+		Sep: 9,
+		Sept: 9,
+		September: 9,
+		Oct: 10,
+		October: 10,
+		Nov: 11,
+		November: 11,
+		Dec: 12,
+		December: 12,
+	};
+	const month = months[monthName];
+	if (!month) {
+		return null;
+	}
+	const day = Number(dayText);
+	const year = Number(yearText);
+	if (!Number.isFinite(day) || !Number.isFinite(year)) {
+		return null;
+	}
+	return { year, month, day };
 }
 
 function replaceCommitGroupTitle(node) {
-    const parsed = parseCommitGroupTitle(node);
-    if (!parsed) {
-        return;
-    }
-    const month = pad2(parsed.month);
-    const day = pad2(parsed.day);
-    node.textContent = `${COMMIT_GROUP_PREFIX}${parsed.year}-${month}-${day}`;
+	const parsed = parseCommitGroupTitle(node);
+	if (!parsed) {
+		return;
+	}
+	const month = pad2(parsed.month);
+	const day = pad2(parsed.day);
+	node.textContent = `${COMMIT_GROUP_PREFIX}${parsed.year}-${month}-${day}`;
 }
 
 function refreshAll() {
-    const nodes = document.querySelectorAll(RELATIVE_TIME_SELECTOR);
-    for (const node of nodes) {
-        updateRelativeTimeNode(node);
-    }
-    const titles = document.querySelectorAll(COMMIT_GROUP_TITLE_SELECTOR);
-    for (const title of titles) {
-        replaceCommitGroupTitle(title);
-    }
+	const nodes = document.querySelectorAll(RELATIVE_TIME_SELECTOR);
+	for (const node of nodes) {
+		updateRelativeTimeNode(node);
+	}
+	const titles = document.querySelectorAll(COMMIT_GROUP_TITLE_SELECTOR);
+	for (const title of titles) {
+		replaceCommitGroupTitle(title);
+	}
 }
 
 function setupObserver() {
-    let pending = false;
-    const schedule = () => {
-        if (pending) {
-            return;
-        }
-        pending = true;
-        window.requestAnimationFrame(() => {
-            pending = false;
-            refreshAll();
-        });
-    };
+	let pending = false;
+	const schedule = () => {
+		if (pending) {
+			return;
+		}
+		pending = true;
+		window.requestAnimationFrame(() => {
+			pending = false;
+			refreshAll();
+		});
+	};
 
-    setupRelativeTimeHook(schedule);
-    schedule();
+	setupRelativeTimeHook(schedule);
+	schedule();
 
-    const observer = new MutationObserver(schedule);
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
+	const observer = new MutationObserver(schedule);
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
 
-    document.addEventListener('pjax:end', schedule);
-    document.addEventListener('turbo:load', schedule);
+	document.addEventListener("pjax:end", schedule);
+	document.addEventListener("turbo:load", schedule);
 }
 
 try {
-    if (document.body) {
-        setupObserver();
-    } else {
-        document.addEventListener('DOMContentLoaded', setupObserver, {
-            once: true,
-        });
-    }
+	if (document.body) {
+		setupObserver();
+	} else {
+		document.addEventListener("DOMContentLoaded", setupObserver, {
+			once: true,
+		});
+	}
 } catch (error) {
-    console.error(`[${SCRIPT_NAME}]`, error);
+	console.error(`[${SCRIPT_NAME}]`, error);
 }

--- a/scripts/GitHubDeepWiki.user.js
+++ b/scripts/GitHubDeepWiki.user.js
@@ -10,23 +10,22 @@
 // @version      20260531
 // @license      MIT
 // ==/UserScript==
-'use strict';
 
-const BUTTON_ID = 'x-deepwiki-link-button';
-const BUTTON_CLASS = 'x-deepwiki-link';
-const STYLE_ID = 'x-deepwiki-link-style';
-const LOG_PREFIX = '[GitHubDeepWiki]';
+const BUTTON_ID = "x-deepwiki-link-button";
+const BUTTON_CLASS = "x-deepwiki-link";
+const STYLE_ID = "x-deepwiki-link-style";
+const LOG_PREFIX = "[GitHubDeepWiki]";
 const ICON_DATA_URL =
-    'https://raw.githubusercontent.com/DCjanus/userscripts/master/assets/deepwiki.svg';
+	"https://raw.githubusercontent.com/DCjanus/userscripts/master/assets/deepwiki.svg";
 
 function ensureStyle() {
-    if (document.getElementById(STYLE_ID)) {
-        return;
-    }
+	if (document.getElementById(STYLE_ID)) {
+		return;
+	}
 
-    const style = document.createElement('style');
-    style.id = STYLE_ID;
-    style.textContent = `
+	const style = document.createElement("style");
+	style.id = STYLE_ID;
+	style.textContent = `
         .${BUTTON_CLASS} {
             align-items: center;
             display: inline-flex;
@@ -47,338 +46,331 @@ function ensureStyle() {
         }
     `;
 
-    document.head.appendChild(style);
+	document.head.appendChild(style);
 }
 
 function getRepoInfo() {
-    const container = document.querySelector('#repo-title-component');
-    if (!container) {
-        return null;
-    }
+	const container = document.querySelector("#repo-title-component");
+	if (!container) {
+		return null;
+	}
 
-    const visibilityLabel = container.querySelector('.Label');
-    if (!visibilityLabel || !visibilityLabel.textContent) {
-        return null;
-    }
+	const visibilityLabel = container.querySelector(".Label");
+	if (!visibilityLabel?.textContent) {
+		return null;
+	}
 
-    const visibilityText = visibilityLabel.textContent.trim().toLowerCase();
-    const isPublicRepo =
-        visibilityText === 'public' || visibilityText === 'public archive';
-    if (!isPublicRepo) {
-        return null;
-    }
+	const visibilityText = visibilityLabel.textContent.trim().toLowerCase();
+	const isPublicRepo =
+		visibilityText === "public" || visibilityText === "public archive";
+	if (!isPublicRepo) {
+		return null;
+	}
 
-    const repoLink =
-        container.querySelector('strong[itemprop="name"] a[href]') ||
-        container.querySelector('a[href]');
-    if (!repoLink) {
-        return null;
-    }
+	const repoLink =
+		container.querySelector('strong[itemprop="name"] a[href]') ||
+		container.querySelector("a[href]");
+	if (!repoLink) {
+		return null;
+	}
 
-    const href = repoLink.getAttribute('href');
-    if (!href) {
-        return null;
-    }
+	const href = repoLink.getAttribute("href");
+	if (!href) {
+		return null;
+	}
 
-    const url = new URL(href, window.location.origin);
-    const parts = url.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) {
-        return null;
-    }
+	const url = new URL(href, window.location.origin);
+	const parts = url.pathname.split("/").filter(Boolean);
+	if (parts.length < 2) {
+		return null;
+	}
 
-    return {
-        container,
-        visibilityLabel,
-        owner: parts[0],
-        repo: parts[1],
-    };
+	return {
+		container,
+		visibilityLabel,
+		owner: parts[0],
+		repo: parts[1],
+	};
 }
 
 function insertDeepWikiButton() {
-    const info = getRepoInfo();
-    if (!info) {
-        const existing = document.getElementById(BUTTON_ID);
-        if (existing) {
-            existing.remove();
-        }
-        return false;
-    }
+	const info = getRepoInfo();
+	if (!info) {
+		const existing = document.getElementById(BUTTON_ID);
+		if (existing) {
+			existing.remove();
+		}
+		return false;
+	}
 
-    const deepWikiUrl = `https://deepwiki.com/${info.owner}/${info.repo}`;
-    const existing = document.getElementById(BUTTON_ID);
-    if (existing) {
-        if (existing.getAttribute('href') !== deepWikiUrl) {
-            existing.setAttribute('href', deepWikiUrl);
-        }
-        return true;
-    }
+	const deepWikiUrl = `https://deepwiki.com/${info.owner}/${info.repo}`;
+	const existing = document.getElementById(BUTTON_ID);
+	if (existing) {
+		if (existing.getAttribute("href") !== deepWikiUrl) {
+			existing.setAttribute("href", deepWikiUrl);
+		}
+		return true;
+	}
 
-    ensureStyle();
+	ensureStyle();
 
-    const link = document.createElement('a');
-    link.id = BUTTON_ID;
-    link.className = `Label Label--secondary v-align-middle ${BUTTON_CLASS}`;
-    link.href = deepWikiUrl;
-    link.target = '_blank';
-    link.rel = 'noopener noreferrer';
-    link.setAttribute('aria-label', 'Open DeepWiki');
+	const link = document.createElement("a");
+	link.id = BUTTON_ID;
+	link.className = `Label Label--secondary v-align-middle ${BUTTON_CLASS}`;
+	link.href = deepWikiUrl;
+	link.target = "_blank";
+	link.rel = "noopener noreferrer";
+	link.setAttribute("aria-label", "Open DeepWiki");
 
-    const icon = document.createElement('img');
-    icon.src = ICON_DATA_URL;
-    icon.alt = '';
-    icon.setAttribute('aria-hidden', 'true');
+	const icon = document.createElement("img");
+	icon.src = ICON_DATA_URL;
+	icon.alt = "";
+	icon.setAttribute("aria-hidden", "true");
 
-    const text = document.createElement('span');
-    text.textContent = 'DeepWiki';
+	const text = document.createElement("span");
+	text.textContent = "DeepWiki";
 
-    link.appendChild(icon);
-    link.appendChild(text);
+	link.appendChild(icon);
+	link.appendChild(text);
 
-    info.visibilityLabel.insertAdjacentElement('afterend', link);
+	info.visibilityLabel.insertAdjacentElement("afterend", link);
 
-    return true;
+	return true;
 }
 
 function parseDeepWikiMetadata() {
-    const scripts = Array.from(document.scripts);
-    const generatedRegex = /"generated_at":"([^"]+)"/;
-    let generatedAt = null;
+	const scripts = Array.from(document.scripts);
+	const generatedRegex = /"generated_at":"([^"]+)"/;
+	let generatedAt = null;
 
-    for (const script of scripts) {
-        const text = script.textContent;
-        if (!text) {
-            continue;
-        }
+	for (const script of scripts) {
+		const text = script.textContent;
+		if (!text) {
+			continue;
+		}
 
-        if (!generatedAt) {
-            const match = text.match(generatedRegex);
-            if (match) {
-                generatedAt = match[1];
-            }
-        }
+		if (!generatedAt) {
+			const match = text.match(generatedRegex);
+			if (match) {
+				generatedAt = match[1];
+			}
+		}
 
-        if (generatedAt) {
-            break;
-        }
-    }
+		if (generatedAt) {
+			break;
+		}
+	}
 
-    if (!generatedAt) {
-        const ldJson = document.querySelector(
-            'script[type="application/ld+json"]',
-        );
-        if (ldJson && ldJson.textContent) {
-            try {
-                const data = JSON.parse(ldJson.textContent);
-                if (data && data.dateModified) {
-                    generatedAt = data.dateModified;
-                }
-            } catch (error) {
-                console.warn(
-                    '[GitHubDeepWiki] 解析 DeepWiki 元信息失败',
-                    error,
-                );
-            }
-        }
-    }
+	if (!generatedAt) {
+		const ldJson = document.querySelector('script[type="application/ld+json"]');
+		if (ldJson?.textContent) {
+			try {
+				const data = JSON.parse(ldJson.textContent);
+				if (data?.dateModified) {
+					generatedAt = data.dateModified;
+				}
+			} catch (error) {
+				console.warn("[GitHubDeepWiki] 解析 DeepWiki 元信息失败", error);
+			}
+		}
+	}
 
-    return {
-        generatedAt,
-    };
+	return {
+		generatedAt,
+	};
 }
 
 function formatRelativeTime(targetDate) {
-    const diffMs = Date.now() - targetDate.getTime();
-    const diffSeconds = Math.max(0, Math.floor(diffMs / 1000));
-    const diffMinutes = Math.floor(diffSeconds / 60);
-    const diffHours = Math.floor(diffMinutes / 60);
-    const diffDays = Math.floor(diffHours / 24);
+	const diffMs = Date.now() - targetDate.getTime();
+	const diffSeconds = Math.max(0, Math.floor(diffMs / 1000));
+	const diffMinutes = Math.floor(diffSeconds / 60);
+	const diffHours = Math.floor(diffMinutes / 60);
+	const diffDays = Math.floor(diffHours / 24);
 
-    if (diffDays >= 1) {
-        return `${diffDays} ${diffDays === 1 ? 'day' : 'days'} ago`;
-    }
-    if (diffHours >= 1) {
-        return `${diffHours} ${diffHours === 1 ? 'hour' : 'hours'} ago`;
-    }
-    if (diffMinutes >= 1) {
-        return `${diffMinutes} ${diffMinutes === 1 ? 'minute' : 'minutes'} ago`;
-    }
-    return `${diffSeconds} ${diffSeconds === 1 ? 'second' : 'seconds'} ago`;
+	if (diffDays >= 1) {
+		return `${diffDays} ${diffDays === 1 ? "day" : "days"} ago`;
+	}
+	if (diffHours >= 1) {
+		return `${diffHours} ${diffHours === 1 ? "hour" : "hours"} ago`;
+	}
+	if (diffMinutes >= 1) {
+		return `${diffMinutes} ${diffMinutes === 1 ? "minute" : "minutes"} ago`;
+	}
+	return `${diffSeconds} ${diffSeconds === 1 ? "second" : "seconds"} ago`;
 }
 
 function normalizeGeneratedAt(value) {
-    if (!value) {
-        return value;
-    }
-    const trimmed = value.trim();
-    if (!trimmed) {
-        return trimmed;
-    }
-    // DeepWiki 的 generated_at 常不带时区信息，按 UTC 解析以避免本地时区偏差。
-    const hasTimezone = /Z$|[+-]\d{2}:\d{2}$|[+-]\d{2}\d{2}$/.test(trimmed);
-    if (hasTimezone) {
-        return trimmed;
-    }
-    return `${trimmed}Z`;
+	if (!value) {
+		return value;
+	}
+	const trimmed = value.trim();
+	if (!trimmed) {
+		return trimmed;
+	}
+	// DeepWiki 的 generated_at 常不带时区信息，按 UTC 解析以避免本地时区偏差。
+	const hasTimezone = /Z$|[+-]\d{2}:\d{2}$|[+-]\d{2}\d{2}$/.test(trimmed);
+	if (hasTimezone) {
+		return trimmed;
+	}
+	return `${trimmed}Z`;
 }
 
 function getDeepWikiRepoInfo() {
-    const parts = window.location.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) {
-        return null;
-    }
+	const parts = window.location.pathname.split("/").filter(Boolean);
+	if (parts.length < 2) {
+		return null;
+	}
 
-    return {
-        owner: parts[0],
-        repo: parts[1],
-    };
+	return {
+		owner: parts[0],
+		repo: parts[1],
+	};
 }
 
 function findDeepWikiTitleElement(repoInfo) {
-    const link = document.querySelector('a[title="Open repository"]');
-    console.log(LOG_PREFIX, 'repo link found:', Boolean(link), repoInfo);
-    return link;
+	const link = document.querySelector('a[title="Open repository"]');
+	console.log(LOG_PREFIX, "repo link found:", Boolean(link), repoInfo);
+	return link;
 }
 
 function getRepoLinkTextNode(link) {
-    for (const node of link.childNodes) {
-        if (node.nodeType === Node.TEXT_NODE) {
-            return node;
-        }
-    }
-    return null;
+	for (const node of link.childNodes) {
+		if (node.nodeType === Node.TEXT_NODE) {
+			return node;
+		}
+	}
+	return null;
 }
 
 function setRepoLinkSuffix(link, repoInfo, suffixText) {
-    const dataKey = 'deepwikiBaseText';
-    let baseText = link.dataset[dataKey];
-    let textNode = getRepoLinkTextNode(link);
+	const dataKey = "deepwikiBaseText";
+	let baseText = link.dataset[dataKey];
+	let textNode = getRepoLinkTextNode(link);
 
-    if (!baseText) {
-        if (textNode) {
-            baseText = textNode.nodeValue.trim();
-        }
-        if (!baseText) {
-            baseText = repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : '';
-        }
-        link.dataset[dataKey] = baseText;
-        console.log(LOG_PREFIX, 'base text set:', baseText);
-    }
+	if (!baseText) {
+		if (textNode) {
+			baseText = textNode.nodeValue.trim();
+		}
+		if (!baseText) {
+			baseText = repoInfo ? `${repoInfo.owner}/${repoInfo.repo}` : "";
+		}
+		link.dataset[dataKey] = baseText;
+		console.log(LOG_PREFIX, "base text set:", baseText);
+	}
 
-    const fullText = suffixText ? `${baseText} ${suffixText}` : baseText;
-    console.log(LOG_PREFIX, 'update title text:', fullText);
-    if (textNode) {
-        textNode.nodeValue = fullText;
-        return;
-    }
+	const fullText = suffixText ? `${baseText} ${suffixText}` : baseText;
+	console.log(LOG_PREFIX, "update title text:", fullText);
+	if (textNode) {
+		textNode.nodeValue = fullText;
+		return;
+	}
 
-    textNode = document.createTextNode(fullText);
-    link.insertBefore(textNode, link.firstChild);
+	textNode = document.createTextNode(fullText);
+	link.insertBefore(textNode, link.firstChild);
 }
 
 async function updateDeepWikiInfo() {
-    const repoInfo = getDeepWikiRepoInfo();
-    if (!repoInfo) {
-        console.log(LOG_PREFIX, 'repo info missing');
-        return;
-    }
+	const repoInfo = getDeepWikiRepoInfo();
+	if (!repoInfo) {
+		console.log(LOG_PREFIX, "repo info missing");
+		return;
+	}
 
-    const title = findDeepWikiTitleElement(repoInfo);
-    if (!title) {
-        console.log(LOG_PREFIX, 'repo title link not found');
-        return;
-    }
+	const title = findDeepWikiTitleElement(repoInfo);
+	if (!title) {
+		console.log(LOG_PREFIX, "repo title link not found");
+		return;
+	}
 
-    const metadata = parseDeepWikiMetadata();
-    console.log(LOG_PREFIX, 'metadata:', metadata);
-    if (!metadata.generatedAt) {
-        setRepoLinkSuffix(title, repoInfo, '(time unavailable)');
-        return;
-    }
+	const metadata = parseDeepWikiMetadata();
+	console.log(LOG_PREFIX, "metadata:", metadata);
+	if (!metadata.generatedAt) {
+		setRepoLinkSuffix(title, repoInfo, "(time unavailable)");
+		return;
+	}
 
-    let baseGeneratedText = '';
-    if (metadata.generatedAt) {
-        const normalizedGeneratedAt = normalizeGeneratedAt(
-            metadata.generatedAt,
-        );
-        const generatedDate = new Date(normalizedGeneratedAt);
-        if (!Number.isNaN(generatedDate.getTime())) {
-            baseGeneratedText = `indexed at ${formatRelativeTime(generatedDate)}`;
-        }
-    }
+	let baseGeneratedText = "";
+	if (metadata.generatedAt) {
+		const normalizedGeneratedAt = normalizeGeneratedAt(metadata.generatedAt);
+		const generatedDate = new Date(normalizedGeneratedAt);
+		if (!Number.isNaN(generatedDate.getTime())) {
+			baseGeneratedText = `indexed at ${formatRelativeTime(generatedDate)}`;
+		}
+	}
 
-    setRepoLinkSuffix(
-        title,
-        repoInfo,
-        baseGeneratedText ? `(${baseGeneratedText})` : '(time unavailable)',
-    );
+	setRepoLinkSuffix(
+		title,
+		repoInfo,
+		baseGeneratedText ? `(${baseGeneratedText})` : "(time unavailable)",
+	);
 }
 
 function setupObserver() {
-    let pending = false;
+	let pending = false;
 
-    const scheduleInsert = () => {
-        if (pending) {
-            return;
-        }
-        pending = true;
-        window.requestAnimationFrame(() => {
-            pending = false;
-            insertDeepWikiButton();
-        });
-    };
+	const scheduleInsert = () => {
+		if (pending) {
+			return;
+		}
+		pending = true;
+		window.requestAnimationFrame(() => {
+			pending = false;
+			insertDeepWikiButton();
+		});
+	};
 
-    scheduleInsert();
+	scheduleInsert();
 
-    const observer = new MutationObserver(() => {
-        scheduleInsert();
-    });
+	const observer = new MutationObserver(() => {
+		scheduleInsert();
+	});
 
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
 
-    document.addEventListener('pjax:end', scheduleInsert);
-    document.addEventListener('turbo:load', scheduleInsert);
+	document.addEventListener("pjax:end", scheduleInsert);
+	document.addEventListener("turbo:load", scheduleInsert);
 }
 
 function setupDeepWikiObserver() {
-    let pending = false;
-    let lastUrl = window.location.href;
+	let pending = false;
+	let lastUrl = window.location.href;
 
-    const scheduleUpdate = () => {
-        if (pending) {
-            return;
-        }
-        pending = true;
-        window.requestAnimationFrame(() => {
-            pending = false;
-            updateDeepWikiInfo();
-        });
-    };
+	const scheduleUpdate = () => {
+		if (pending) {
+			return;
+		}
+		pending = true;
+		window.requestAnimationFrame(() => {
+			pending = false;
+			updateDeepWikiInfo();
+		});
+	};
 
-    const observer = new MutationObserver(() => {
-        if (window.location.href !== lastUrl) {
-            lastUrl = window.location.href;
-        }
-        scheduleUpdate();
-    });
+	const observer = new MutationObserver(() => {
+		if (window.location.href !== lastUrl) {
+			lastUrl = window.location.href;
+		}
+		scheduleUpdate();
+	});
 
-    observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-    });
+	observer.observe(document.body, {
+		childList: true,
+		subtree: true,
+	});
 
-    window.addEventListener('popstate', scheduleUpdate);
-    scheduleUpdate();
+	window.addEventListener("popstate", scheduleUpdate);
+	scheduleUpdate();
 }
 
 try {
-    if (window.location.hostname === 'github.com') {
-        setupObserver();
-    } else if (window.location.hostname === 'deepwiki.com') {
-        setupDeepWikiObserver();
-    }
+	if (window.location.hostname === "github.com") {
+		setupObserver();
+	} else if (window.location.hostname === "deepwiki.com") {
+		setupDeepWikiObserver();
+	}
 } catch (error) {
-    console.error('[GitHubDeepWiki]', error);
+	console.error("[GitHubDeepWiki]", error);
 }

--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -11,42 +11,39 @@
 // @grant        none
 // @run-at       document-start
 // ==/UserScript==
-'use strict';
 
-const SCRIPT_NAME = 'GitHubPrFileTreeReviewStats';
-const STYLE_ID = 'rgh-pr-file-tree-review-stats-style';
-const STATS_CLASS = 'rgh-pr-file-tree-review-stats';
-const PATCHED_ATTR = 'data-rgh-pr-file-tree-review-stats';
-const VIEWED_ATTR = 'data-rgh-pr-file-viewed';
-const NETWORK_HOOKED = Symbol.for('GitHubPrFileTreeReviewStats.networkHooked');
-const HISTORY_HOOKED = Symbol.for('GitHubPrFileTreeReviewStats.historyHooked');
-const LOCATION_CHANGE_EVENT = 'rgh-pr-file-tree-review-stats-location-change';
+const SCRIPT_NAME = "GitHubPrFileTreeReviewStats";
+const STYLE_ID = "rgh-pr-file-tree-review-stats-style";
+const STATS_CLASS = "rgh-pr-file-tree-review-stats";
+const PATCHED_ATTR = "data-rgh-pr-file-tree-review-stats";
+const VIEWED_ATTR = "data-rgh-pr-file-viewed";
+const NETWORK_HOOKED = Symbol.for("GitHubPrFileTreeReviewStats.networkHooked");
+const HISTORY_HOOKED = Symbol.for("GitHubPrFileTreeReviewStats.historyHooked");
+const LOCATION_CHANGE_EVENT = "rgh-pr-file-tree-review-stats-location-change";
 
 const FILE_SELECTOR =
-    '[id^="diff-"].js-file, [id^="diff-"][class*="Diff-module__diffTargetable"]';
+	'[id^="diff-"].js-file, [id^="diff-"][class*="Diff-module__diffTargetable"]';
 const FILE_HEADER_SELECTOR =
-    '.file-header, [class*="DiffHeader"], [class*="FileHeader"]';
+	'.file-header, [class*="DiffHeader"], [class*="FileHeader"]';
 const VIEWED_CONTROL_SELECTOR =
-    'button[class*="MarkAsViewedButton"], input.js-reviewed-checkbox';
+	'button[class*="MarkAsViewedButton"], input.js-reviewed-checkbox';
 const FILE_TREE_LINK_SELECTOR = 'a[href^="#diff-"]';
 
 let updateScheduled = false;
 let observer = null;
 
 function isPrFilesPage() {
-    return /^\/[^/]+\/[^/]+\/pull\/\d+\/(files|changes)/.test(
-        location.pathname,
-    );
+	return /^\/[^/]+\/[^/]+\/pull\/\d+\/(files|changes)/.test(location.pathname);
 }
 
 function ensureStyle() {
-    if (document.getElementById(STYLE_ID)) {
-        return;
-    }
+	if (document.getElementById(STYLE_ID)) {
+		return;
+	}
 
-    const style = document.createElement('style');
-    style.id = STYLE_ID;
-    style.textContent = `
+	const style = document.createElement("style");
+	style.id = STYLE_ID;
+	style.textContent = `
         li[${VIEWED_ATTR}="false"] a[href^="#diff-"],
         a[${VIEWED_ATTR}="false"][href^="#diff-"] {
             font-weight: 600;
@@ -78,423 +75,421 @@ function ensureStyle() {
             color: var(--fgColor-danger, var(--color-danger-fg, #d1242f));
         }
     `;
-    document.head.appendChild(style);
+	document.head.appendChild(style);
 }
 
 function parseCount(text, word) {
-    const match = text.match(new RegExp(`(\\d+)\\s+${word}s?`, 'i'));
-    return match ? Number(match[1]) : null;
+	const match = text.match(new RegExp(`(\\d+)\\s+${word}s?`, "i"));
+	return match ? Number(match[1]) : null;
 }
 
 function parseLineStats(text) {
-    const normalized = text.replace(/\s+/g, ' ').trim();
-    const additions = parseCount(normalized, 'addition');
-    const deletions = parseCount(normalized, 'deletion');
-    if (additions !== null || deletions !== null) {
-        return {
-            additions: additions ?? 0,
-            deletions: deletions ?? 0,
-        };
-    }
+	const normalized = text.replace(/\s+/g, " ").trim();
+	const additions = parseCount(normalized, "addition");
+	const deletions = parseCount(normalized, "deletion");
+	if (additions !== null || deletions !== null) {
+		return {
+			additions: additions ?? 0,
+			deletions: deletions ?? 0,
+		};
+	}
 
-    const compactMatch = normalized.match(/[+＋]\s*(\d+)\s*[−-]\s*(\d+)/);
-    if (compactMatch) {
-        return {
-            additions: Number(compactMatch[1]),
-            deletions: Number(compactMatch[2]),
-        };
-    }
+	const compactMatch = normalized.match(/[+＋]\s*(\d+)\s*[−-]\s*(\d+)/);
+	if (compactMatch) {
+		return {
+			additions: Number(compactMatch[1]),
+			deletions: Number(compactMatch[2]),
+		};
+	}
 
-    return null;
+	return null;
 }
 
 function getFileStats(file) {
-    const header = file.querySelector(FILE_HEADER_SELECTOR);
-    if (!header) {
-        return null;
-    }
+	const header = file.querySelector(FILE_HEADER_SELECTOR);
+	if (!header) {
+		return null;
+	}
 
-    const statText =
-        Array.from(header.querySelectorAll('.sr-only'))
-            .map((element) => element.textContent || '')
-            .find((text) => /addition|deletion|Lines changed/i.test(text)) ||
-        header.textContent ||
-        '';
+	const statText =
+		Array.from(header.querySelectorAll(".sr-only"))
+			.map((element) => element.textContent || "")
+			.find((text) => /addition|deletion|Lines changed/i.test(text)) ||
+		header.textContent ||
+		"";
 
-    return parseLineStats(statText);
+	return parseLineStats(statText);
 }
 
 function parseBooleanAttribute(value) {
-    if (value === null) {
-        return null;
-    }
+	if (value === null) {
+		return null;
+	}
 
-    if (/^(true|1)$/i.test(value)) {
-        return true;
-    }
-    if (/^(false|0)$/i.test(value)) {
-        return false;
-    }
+	if (/^(true|1)$/i.test(value)) {
+		return true;
+	}
+	if (/^(false|0)$/i.test(value)) {
+		return false;
+	}
 
-    return null;
+	return null;
 }
 
 function getViewedState(file) {
-    const dataViewed = parseBooleanAttribute(
-        file.getAttribute('data-file-user-viewed') ||
-            file
-                .querySelector('[data-file-user-viewed]')
-                ?.getAttribute('data-file-user-viewed') ||
-            null,
-    );
-    if (typeof dataViewed === 'boolean') {
-        return dataViewed;
-    }
+	const dataViewed = parseBooleanAttribute(
+		file.getAttribute("data-file-user-viewed") ||
+			file
+				.querySelector("[data-file-user-viewed]")
+				?.getAttribute("data-file-user-viewed") ||
+			null,
+	);
+	if (typeof dataViewed === "boolean") {
+		return dataViewed;
+	}
 
-    const input = file.querySelector('input.js-reviewed-checkbox');
-    if (input) {
-        return input.checked;
-    }
+	const input = file.querySelector("input.js-reviewed-checkbox");
+	if (input) {
+		return input.checked;
+	}
 
-    const button = file.querySelector(
-        'button[class*="MarkAsViewedButton"], button[aria-pressed][aria-label*="Viewed"], button[aria-pressed][aria-label*="viewed"]',
-    );
-    if (!button) {
-        return false;
-    }
+	const button = file.querySelector(
+		'button[class*="MarkAsViewedButton"], button[aria-pressed][aria-label*="Viewed"], button[aria-pressed][aria-label*="viewed"]',
+	);
+	if (!button) {
+		return false;
+	}
 
-    const pressed = button.getAttribute('aria-pressed');
-    if (pressed === 'true') {
-        return true;
-    }
-    if (pressed === 'false') {
-        return false;
-    }
+	const pressed = button.getAttribute("aria-pressed");
+	if (pressed === "true") {
+		return true;
+	}
+	if (pressed === "false") {
+		return false;
+	}
 
-    const label = button.getAttribute('aria-label') || '';
-    if (/not viewed/i.test(label)) {
-        return false;
-    }
-    if (/viewed/i.test(label)) {
-        return true;
-    }
+	const label = button.getAttribute("aria-label") || "";
+	if (/not viewed/i.test(label)) {
+		return false;
+	}
+	if (/viewed/i.test(label)) {
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 function getHashFromLink(link) {
-    const href = link.getAttribute('href');
-    return href?.startsWith('#diff-') ? href.slice(1) : null;
+	const href = link.getAttribute("href");
+	return href?.startsWith("#diff-") ? href.slice(1) : null;
 }
 
 function getFileTreeRow(link) {
-    return (
-        link.closest('li[class*="file-tree-row"]') ||
-        link.closest('li.ActionListItem') ||
-        (link.matches('.ActionList-content') ? link : null)
-    );
+	return (
+		link.closest('li[class*="file-tree-row"]') ||
+		link.closest("li.ActionListItem") ||
+		(link.matches(".ActionList-content") ? link : null)
+	);
 }
 
 function collectFileTreeRows() {
-    const rowsByHash = new Map();
+	const rowsByHash = new Map();
 
-    for (const link of document.querySelectorAll(FILE_TREE_LINK_SELECTOR)) {
-        const hash = getHashFromLink(link);
-        const row = getFileTreeRow(link);
-        if (hash && row) {
-            rowsByHash.set(hash, { row, link });
-        }
-    }
+	for (const link of document.querySelectorAll(FILE_TREE_LINK_SELECTOR)) {
+		const hash = getHashFromLink(link);
+		const row = getFileTreeRow(link);
+		if (hash && row) {
+			rowsByHash.set(hash, { row, link });
+		}
+	}
 
-    return rowsByHash;
+	return rowsByHash;
 }
 
 function getStatsHost(row, link) {
-    if (row === link) {
-        return link;
-    }
+	if (row === link) {
+		return link;
+	}
 
-    return (
-        row.querySelector('[class*="TreeViewItemContent"]') ||
-        row.querySelector('.ActionList-content') ||
-        link.closest('[class*="TreeViewItemContentText"]') ||
-        link.parentElement
-    );
+	return (
+		row.querySelector('[class*="TreeViewItemContent"]') ||
+		row.querySelector(".ActionList-content") ||
+		link.closest('[class*="TreeViewItemContentText"]') ||
+		link.parentElement
+	);
 }
 
 function setAttributeValue(element, name, value) {
-    if (value === null) {
-        if (element.hasAttribute(name)) {
-            element.removeAttribute(name);
-        }
-        return;
-    }
+	if (value === null) {
+		if (element.hasAttribute(name)) {
+			element.removeAttribute(name);
+		}
+		return;
+	}
 
-    const stringValue = String(value);
-    if (element.getAttribute(name) !== stringValue) {
-        element.setAttribute(name, stringValue);
-    }
+	const stringValue = String(value);
+	if (element.getAttribute(name) !== stringValue) {
+		element.setAttribute(name, stringValue);
+	}
 }
 
 function renderStatsElement(stats) {
-    const element = document.createElement('span');
-    const added = document.createElement('span');
-    const deleted = document.createElement('span');
+	const element = document.createElement("span");
+	const added = document.createElement("span");
+	const deleted = document.createElement("span");
 
-    element.className = STATS_CLASS;
-    element.setAttribute(
-        'aria-label',
-        `${stats.additions} additions, ${stats.deletions} deletions`,
-    );
-    element.title = `${stats.additions} additions, ${stats.deletions} deletions`;
+	element.className = STATS_CLASS;
+	element.setAttribute(
+		"aria-label",
+		`${stats.additions} additions, ${stats.deletions} deletions`,
+	);
+	element.title = `${stats.additions} additions, ${stats.deletions} deletions`;
 
-    added.className = `${STATS_CLASS}__added`;
-    added.textContent = `+${stats.additions}`;
+	added.className = `${STATS_CLASS}__added`;
+	added.textContent = `+${stats.additions}`;
 
-    deleted.className = `${STATS_CLASS}__deleted`;
-    deleted.textContent = `-${stats.deletions}`;
+	deleted.className = `${STATS_CLASS}__deleted`;
+	deleted.textContent = `-${stats.deletions}`;
 
-    element.append(added, deleted);
-    return element;
+	element.append(added, deleted);
+	return element;
 }
 
 function updateRow(rowInfo, stats) {
-    const { row, link } = rowInfo;
-    const host = getStatsHost(row, link);
-    if (!host) {
-        return;
-    }
+	const { row, link } = rowInfo;
+	const host = getStatsHost(row, link);
+	if (!host) {
+		return;
+	}
 
-    setAttributeValue(row, PATCHED_ATTR, true);
-    setAttributeValue(
-        row,
-        VIEWED_ATTR,
-        typeof stats.viewed === 'boolean' ? stats.viewed : null,
-    );
+	setAttributeValue(row, PATCHED_ATTR, true);
+	setAttributeValue(
+		row,
+		VIEWED_ATTR,
+		typeof stats.viewed === "boolean" ? stats.viewed : null,
+	);
 
-    if (row === link) {
-        setAttributeValue(
-            link,
-            VIEWED_ATTR,
-            typeof stats.viewed === 'boolean' ? stats.viewed : null,
-        );
-    }
+	if (row === link) {
+		setAttributeValue(
+			link,
+			VIEWED_ATTR,
+			typeof stats.viewed === "boolean" ? stats.viewed : null,
+		);
+	}
 
-    const existing = host.querySelector(`.${STATS_CLASS}`);
-    const expected = `+${stats.additions}-${stats.deletions}`;
-    if (existing) {
-        if (existing.textContent.replace(/\s+/g, '') !== expected) {
-            existing.replaceWith(renderStatsElement(stats));
-        }
-        return;
-    }
+	const existing = host.querySelector(`.${STATS_CLASS}`);
+	const expected = `+${stats.additions}-${stats.deletions}`;
+	if (existing) {
+		if (existing.textContent.replace(/\s+/g, "") !== expected) {
+			existing.replaceWith(renderStatsElement(stats));
+		}
+		return;
+	}
 
-    host.appendChild(renderStatsElement(stats));
+	host.appendChild(renderStatsElement(stats));
 }
 
 function updateFile(file, rowsByHash = collectFileTreeRows(), viewedOverride) {
-    const stats = getFileStats(file);
-    if (!stats) {
-        return;
-    }
+	const stats = getFileStats(file);
+	if (!stats) {
+		return;
+	}
 
-    const rowInfo = rowsByHash.get(file.id);
-    if (!rowInfo) {
-        return;
-    }
+	const rowInfo = rowsByHash.get(file.id);
+	if (!rowInfo) {
+		return;
+	}
 
-    updateRow(rowInfo, {
-        ...stats,
-        viewed:
-            typeof viewedOverride === 'boolean'
-                ? viewedOverride
-                : getViewedState(file),
-    });
+	updateRow(rowInfo, {
+		...stats,
+		viewed:
+			typeof viewedOverride === "boolean"
+				? viewedOverride
+				: getViewedState(file),
+	});
 }
 
 function updateFileTree() {
-    updateScheduled = false;
-    if (!isPrFilesPage() || !document.body) {
-        return;
-    }
+	updateScheduled = false;
+	if (!isPrFilesPage() || !document.body) {
+		return;
+	}
 
-    ensureStyle();
-    const rowsByHash = collectFileTreeRows();
-    for (const file of document.querySelectorAll(FILE_SELECTOR)) {
-        updateFile(file, rowsByHash);
-    }
+	ensureStyle();
+	const rowsByHash = collectFileTreeRows();
+	for (const file of document.querySelectorAll(FILE_SELECTOR)) {
+		updateFile(file, rowsByHash);
+	}
 }
 
 function scheduleUpdate() {
-    if (updateScheduled) {
-        return;
-    }
+	if (updateScheduled) {
+		return;
+	}
 
-    updateScheduled = true;
-    requestAnimationFrame(updateFileTree);
+	updateScheduled = true;
+	requestAnimationFrame(updateFileTree);
 }
 
 function schedulePostNetworkUpdate() {
-    if (!isPrFilesPage()) {
-        return;
-    }
+	if (!isPrFilesPage()) {
+		return;
+	}
 
-    requestAnimationFrame(() => {
-        requestAnimationFrame(scheduleUpdate);
-    });
+	requestAnimationFrame(() => {
+		requestAnimationFrame(scheduleUpdate);
+	});
 }
 
 function getFileFromControl(control) {
-    return control.closest(FILE_SELECTOR);
+	return control.closest(FILE_SELECTOR);
 }
 
 function handleViewedClick(event) {
-    if (!(event.target instanceof Element)) {
-        return;
-    }
+	if (!(event.target instanceof Element)) {
+		return;
+	}
 
-    const control = event.target.closest(VIEWED_CONTROL_SELECTOR);
-    if (!control || control instanceof HTMLInputElement) {
-        return;
-    }
+	const control = event.target.closest(VIEWED_CONTROL_SELECTOR);
+	if (!control || control instanceof HTMLInputElement) {
+		return;
+	}
 
-    const file = getFileFromControl(control);
-    if (!file) {
-        return;
-    }
+	const file = getFileFromControl(control);
+	if (!file) {
+		return;
+	}
 
-    const currentViewed = getViewedState(file);
-    if (typeof currentViewed === 'boolean') {
-        updateFile(file, collectFileTreeRows(), !currentViewed);
-    }
+	const currentViewed = getViewedState(file);
+	if (typeof currentViewed === "boolean") {
+		updateFile(file, collectFileTreeRows(), !currentViewed);
+	}
 }
 
 function handleViewedChange(event) {
-    if (
-        event.target instanceof HTMLInputElement &&
-        event.target.matches('input.js-reviewed-checkbox')
-    ) {
-        const file = getFileFromControl(event.target);
-        if (file) {
-            updateFile(file);
-        }
-    }
+	if (
+		event.target instanceof HTMLInputElement &&
+		event.target.matches("input.js-reviewed-checkbox")
+	) {
+		const file = getFileFromControl(event.target);
+		if (file) {
+			updateFile(file);
+		}
+	}
 }
 
 function installNetworkHooks() {
-    if (window[NETWORK_HOOKED]) {
-        return;
-    }
+	if (window[NETWORK_HOOKED]) {
+		return;
+	}
 
-    Object.defineProperty(window, NETWORK_HOOKED, {
-        value: true,
-    });
+	Object.defineProperty(window, NETWORK_HOOKED, {
+		value: true,
+	});
 
-    const nativeFetch = window.fetch;
-    if (typeof nativeFetch === 'function') {
-        window.fetch = async function fetchWithReviewStatsUpdate(...args) {
-            try {
-                return await nativeFetch.apply(this, args);
-            } finally {
-                schedulePostNetworkUpdate();
-            }
-        };
-    }
+	const nativeFetch = window.fetch;
+	if (typeof nativeFetch === "function") {
+		window.fetch = async function fetchWithReviewStatsUpdate(...args) {
+			try {
+				return await nativeFetch.apply(this, args);
+			} finally {
+				schedulePostNetworkUpdate();
+			}
+		};
+	}
 
-    const nativeSend = XMLHttpRequest.prototype.send;
-    XMLHttpRequest.prototype.send = function sendWithReviewStatsUpdate(
-        ...args
-    ) {
-        this.addEventListener('loadend', schedulePostNetworkUpdate, {
-            once: true,
-        });
-        return nativeSend.apply(this, args);
-    };
+	const nativeSend = XMLHttpRequest.prototype.send;
+	XMLHttpRequest.prototype.send = function sendWithReviewStatsUpdate(...args) {
+		this.addEventListener("loadend", schedulePostNetworkUpdate, {
+			once: true,
+		});
+		return nativeSend.apply(this, args);
+	};
 }
 
 function setupLocationChangeEvent() {
-    const dispatchLocationChange = () => {
-        window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
-    };
+	const dispatchLocationChange = () => {
+		window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+	};
 
-    if (!window[HISTORY_HOOKED]) {
-        Object.defineProperty(window, HISTORY_HOOKED, {
-            value: true,
-        });
+	if (!window[HISTORY_HOOKED]) {
+		Object.defineProperty(window, HISTORY_HOOKED, {
+			value: true,
+		});
 
-        for (const methodName of ['pushState', 'replaceState']) {
-            const nativeMethod = history[methodName];
-            history[methodName] = function historyWithLocationChange(...args) {
-                const result = nativeMethod.apply(this, args);
-                dispatchLocationChange();
-                return result;
-            };
-        }
-    }
+		for (const methodName of ["pushState", "replaceState"]) {
+			const nativeMethod = history[methodName];
+			history[methodName] = function historyWithLocationChange(...args) {
+				const result = nativeMethod.apply(this, args);
+				dispatchLocationChange();
+				return result;
+			};
+		}
+	}
 
-    window.addEventListener('popstate', dispatchLocationChange);
+	window.addEventListener("popstate", dispatchLocationChange);
 }
 
 function startPrFilesPage() {
-    if (observer) {
-        return;
-    }
+	if (observer) {
+		return;
+	}
 
-    installNetworkHooks();
-    scheduleUpdate();
+	installNetworkHooks();
+	scheduleUpdate();
 
-    observer = new MutationObserver(scheduleUpdate);
-    observer.observe(document.documentElement, {
-        childList: true,
-        characterData: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: [
-            'aria-label',
-            'aria-pressed',
-            'checked',
-            'class',
-            'data-file-user-viewed',
-            'hidden',
-        ],
-    });
+	observer = new MutationObserver(scheduleUpdate);
+	observer.observe(document.documentElement, {
+		childList: true,
+		characterData: true,
+		subtree: true,
+		attributes: true,
+		attributeFilter: [
+			"aria-label",
+			"aria-pressed",
+			"checked",
+			"class",
+			"data-file-user-viewed",
+			"hidden",
+		],
+	});
 
-    document.addEventListener('click', handleViewedClick, true);
-    document.addEventListener('change', handleViewedChange, true);
+	document.addEventListener("click", handleViewedClick, true);
+	document.addEventListener("change", handleViewedChange, true);
 }
 
 function stopPrFilesPage() {
-    if (!observer) {
-        return;
-    }
+	if (!observer) {
+		return;
+	}
 
-    observer.disconnect();
-    observer = null;
-    updateScheduled = false;
+	observer.disconnect();
+	observer = null;
+	updateScheduled = false;
 
-    document.removeEventListener('click', handleViewedClick, true);
-    document.removeEventListener('change', handleViewedChange, true);
+	document.removeEventListener("click", handleViewedClick, true);
+	document.removeEventListener("change", handleViewedChange, true);
 }
 
 function refreshForCurrentRoute() {
-    if (!isPrFilesPage()) {
-        stopPrFilesPage();
-        return;
-    }
+	if (!isPrFilesPage()) {
+		stopPrFilesPage();
+		return;
+	}
 
-    startPrFilesPage();
-    scheduleUpdate();
+	startPrFilesPage();
+	scheduleUpdate();
 }
 
 function start() {
-    setupLocationChangeEvent();
+	setupLocationChangeEvent();
 
-    document.addEventListener('turbo:load', refreshForCurrentRoute);
-    document.addEventListener('turbo:render', refreshForCurrentRoute);
-    document.addEventListener('pjax:end', refreshForCurrentRoute);
-    window.addEventListener(LOCATION_CHANGE_EVENT, refreshForCurrentRoute);
+	document.addEventListener("turbo:load", refreshForCurrentRoute);
+	document.addEventListener("turbo:render", refreshForCurrentRoute);
+	document.addEventListener("pjax:end", refreshForCurrentRoute);
+	window.addEventListener(LOCATION_CHANGE_EVENT, refreshForCurrentRoute);
 
-    refreshForCurrentRoute();
+	refreshForCurrentRoute();
 }
 
 start();

--- a/scripts/MediaSpeedToggle.user.js
+++ b/scripts/MediaSpeedToggle.user.js
@@ -15,865 +15,833 @@
 // ==/UserScript==
 
 (() => {
-    'use strict';
-
-    // 参考实现（仅记录思路来源，当前脚本保持个人定制与最小功能）：
-    // - h5player: https://github.com/xxxily/h5player
-    // - Video Speed Controller: https://greasyfork.org/en/scripts/534111-video-speed-controller-control-speed-on-videos-in-any-website
-    // - All Media Speed: https://greasyfork.org/en/scripts/541300-all-media-speed
-    // - Universal Video Speed Adjuster: https://greasyfork.org/en/scripts/550693-universal-video-speed-adjuster
-
-    const RATE_NORMAL = 1;
-    const RATE_FAST = 3;
-    const DEFAULT_RATE = RATE_FAST;
-    const SITE_DEFAULT_RATES = Object.freeze({
-        // 'example.com': RATE_NORMAL,
-    });
-    const REAPPLY_DEBOUNCE_MS = 120;
-    const HEAL_INTERVAL_MS = 1500;
-    const OVERLAY_ID = 'dcjanus-media-speed-overlay';
-    const BILIBILI_VIDEO_TAG_SELECTOR =
-        '.video-tag-container a.tag-link, a.tag-link[href*="from_source=video_tag"]';
-    const BILIBILI_ASMR_TAGS = new Set([
-        '助眠',
-        '催眠',
-        '耳语',
-        '触发音',
-        '采耳',
-        '耳搔',
-    ]);
-    const BILIBILI_MUSIC_TAGS = new Set([
-        '音乐',
-        '音乐现场',
-        '音乐推荐',
-        '音乐综合',
-        '原创音乐',
-        '流行音乐',
-        '歌曲',
-        '音乐选集',
-        '听歌',
-        '翻唱',
-        '男声翻唱',
-        '女声翻唱',
-        '说唱',
-        '演奏',
-        'VOCALOID',
-        'VOCALOID·UTAU',
-        'UTAU',
-        'MV',
-        '华语MV',
-        'mv说唱',
-        'BGM',
-    ]);
-    const BILIBILI_DANCE_TAGS = new Set([
-        '舞蹈',
-        '翻跳',
-        '舞蹈翻跳',
-        '舞蹈随拍',
-        '舞蹈挑战',
-        '热舞',
-        '抖舞',
-        '宅舞',
-        '街舞',
-        '中国舞',
-        '编舞',
-    ]);
-
-    const isMac =
-        navigator.userAgentData?.platform === 'macOS' ||
-        /\bMac(?:intosh)?\b/i.test(navigator.userAgent) ||
-        navigator.platform?.toUpperCase().includes('MAC');
-    let pageOverrideRate = null;
-    let lastUrl = location.href;
-    let pendingApply = 0;
-    let toastTimer = 0;
-    let lastIncrementalApplyAt = 0;
-    let menuCommandIds = [];
-    let lastMenuText = '';
-    let overlayKeydownHandler = null;
-
-    const applyingMap = new WeakMap();
-    const boundMedia = new WeakSet();
-
-    function currentRate() {
-        return resolveRate().rate;
-    }
-
-    function normalizeRate(rate) {
-        const numericRate = Number(rate);
-        if (!Number.isFinite(numericRate)) return null;
-        if (numericRate < 0.0625 || numericRate > 16) return null;
-        return Math.round(numericRate * 100) / 100;
-    }
-
-    function sameRate(a, b) {
-        return Math.abs(a - b) < 0.001;
-    }
-
-    function formatRate(rate) {
-        return `${Number(rate.toFixed(2))}x`;
-    }
-
-    function currentSiteKey() {
-        return location.hostname.replace(/^www\./, '');
-    }
-
-    function isTopWindow() {
-        return window.top === window.self;
-    }
-
-    function getSiteRate() {
-        const siteKey = currentSiteKey();
-        return Object.prototype.hasOwnProperty.call(SITE_DEFAULT_RATES, siteKey)
-            ? SITE_DEFAULT_RATES[siteKey]
-            : null;
-    }
-
-    function detectPageRule() {
-        if (isYouTubeLivePage()) {
-            return {
-                rate: RATE_NORMAL,
-                source: '页面规则',
-                reason: 'YouTube 直播',
-                rule: 'youtube-live',
-            };
-        }
-
-        if (isBilibiliLivePage()) {
-            return {
-                rate: RATE_NORMAL,
-                source: '页面规则',
-                reason: 'B 站直播',
-                rule: 'bilibili-live-host',
-            };
-        }
-
-        const bilibiliTagRule = detectBilibiliTagRule();
-        if (bilibiliTagRule) return bilibiliTagRule;
-
-        return null;
-    }
-
-    function resolveRate() {
-        const siteKey = currentSiteKey();
-        const siteRate = getSiteRate();
-        const base = {
-            siteKey,
-            siteRate,
-            defaultRate: DEFAULT_RATE,
-            pageOverrideRate,
-        };
-
-        if (pageOverrideRate !== null) {
-            return {
-                ...base,
-                rate: pageOverrideRate,
-                source: '本页临时',
-                reason: null,
-                rule: 'page-override',
-            };
-        }
-
-        const pageRule = detectPageRule();
-        if (pageRule) return { ...base, ...pageRule };
-
-        if (siteRate !== null) {
-            return {
-                ...base,
-                rate: siteRate,
-                source: '源码站点默认',
-                reason: siteKey,
-                rule: 'source-site-default',
-            };
-        }
-
-        return {
-            ...base,
-            rate: DEFAULT_RATE,
-            source: '源码默认',
-            reason: null,
-            rule: 'source-default',
-        };
-    }
-
-    function isYouTubeHost() {
-        return /(^|\.)youtube\.com$/i.test(location.hostname);
-    }
-
-    function isBilibiliHost() {
-        return /(^|\.)bilibili\.com$/i.test(location.hostname);
-    }
-
-    function isYouTubeLivePage() {
-        if (!isYouTubeHost()) return false;
-        if (location.pathname.startsWith('/live/')) return true;
-        if (hasLiveMedia()) return true;
-        if (
-            document.querySelector(
-                'meta[itemprop="isLiveBroadcast"][content="True"], meta[itemprop="isLiveBroadcast"][content="true"]',
-            )
-        ) {
-            return true;
-        }
-
-        return hasVisibleLiveBadge('.ytp-live, .ytp-live-badge');
-    }
-
-    function hasLiveMedia() {
-        return Array.from(document.querySelectorAll('video')).some(
-            (media) => media.duration === Infinity,
-        );
-    }
-
-    function hasVisibleLiveBadge(selector) {
-        return Array.from(document.querySelectorAll(selector)).some((el) => {
-            const text = `${el.textContent || ''} ${
-                el.getAttribute('aria-label') || ''
-            }`;
-            if (!/(live|直播)/i.test(text)) return false;
-            const style = window.getComputedStyle(el);
-            if (
-                style.display === 'none' ||
-                style.visibility === 'hidden' ||
-                style.opacity === '0'
-            ) {
-                return false;
-            }
-            return el.getClientRects().length > 0;
-        });
-    }
-
-    function isBilibiliLivePage() {
-        return /^live\.bilibili\.com$/i.test(location.hostname);
-    }
-
-    function detectBilibiliTagRule() {
-        if (!isBilibiliHost()) return false;
-
-        const pageTags = collectBilibiliVideoTags();
-        const asmrTags = pageTags.filter(isBilibiliAsmrTag);
-        if (asmrTags.length > 0) {
-            return {
-                rate: RATE_NORMAL,
-                source: '页面规则',
-                reason: 'B 站 ASMR',
-                rule: 'bilibili-asmr-tags',
-                pageTags,
-                matchedTags: asmrTags,
-            };
-        }
-
-        const musicTags = pageTags.filter((tag) =>
-            BILIBILI_MUSIC_TAGS.has(tag),
-        );
-        if (musicTags.length > 0) {
-            return {
-                rate: RATE_NORMAL,
-                source: '页面规则',
-                reason: 'B 站音乐',
-                rule: 'bilibili-music-tags',
-                pageTags,
-                matchedTags: musicTags,
-            };
-        }
-
-        const danceTags = pageTags.filter((tag) =>
-            BILIBILI_DANCE_TAGS.has(tag),
-        );
-        if (danceTags.length > 0) {
-            return {
-                rate: RATE_NORMAL,
-                source: '页面规则',
-                reason: 'B 站舞蹈',
-                rule: 'bilibili-dance-tags',
-                pageTags,
-                matchedTags: danceTags,
-            };
-        }
-
-        return null;
-    }
-
-    function isBilibiliAsmrTag(tag) {
-        return (
-            tag.toLowerCase().includes('asmr') || BILIBILI_ASMR_TAGS.has(tag)
-        );
-    }
-
-    function collectBilibiliVideoTags() {
-        const domTags = Array.from(
-            document.querySelectorAll(BILIBILI_VIDEO_TAG_SELECTOR),
-            (node) => normalizeBilibiliTag(node.textContent || ''),
-        ).filter(Boolean);
-        const metaTags = collectBilibiliMetaTags();
-
-        return Array.from(new Set([...domTags, ...metaTags]));
-    }
-
-    function collectBilibiliMetaTags() {
-        const keywords = document.querySelector(
-            'meta[itemprop="keywords"], meta[name="keywords"]',
-        )?.content;
-        if (!keywords) return [];
-
-        return keywords.split(',').map(normalizeBilibiliTag).filter(Boolean);
-    }
-
-    function normalizeBilibiliTag(tag) {
-        return tag.trim().replace(/^#+|#+$/g, '');
-    }
-
-    function refreshMenu() {
-        if (!isTopWindow()) return;
-
-        const menuText = formatMenuText(resolveRate());
-        if (menuText === lastMenuText && menuCommandIds.length > 0) return;
-
-        unregisterMenuCommands();
-        menuCommandIds.push(
-            GM_registerMenuCommand(
-                menuText,
-                () => {
-                    showInfoOverlay();
-                },
-                {
-                    title: '查看 MediaSpeedToggle 状态与配置',
-                },
-            ),
-        );
-        lastMenuText = menuText;
-    }
-
-    function unregisterMenuCommands() {
-        menuCommandIds.forEach((id) => {
-            try {
-                GM_unregisterMenuCommand(id);
-            } catch (error) {
-                console.warn(
-                    '[MediaSpeedToggle] failed to unregister menu command:',
-                    error,
-                );
-            }
-        });
-        menuCommandIds = [];
-    }
-
-    function formatMenuText(decision) {
-        return `状态与配置：${formatRate(decision.rate)}（${formatShortReason(decision)}）`;
-    }
-
-    function formatShortReason(decision) {
-        if (decision.reason) return decision.reason;
-
-        if (decision.rule === 'page-override') return '本页临时';
-        if (decision.rule === 'source-site-default') return '站点默认';
-        return '源码默认';
-    }
-
-    function showInfoOverlay() {
-        closeInfoOverlay();
-
-        const overlay = document.createElement('div');
-        overlay.id = OVERLAY_ID;
-        overlay.style.cssText = [
-            'position:fixed',
-            'inset:0',
-            'z-index:2147483647',
-            'background:rgba(15,23,42,.42)',
-            'display:flex',
-            'align-items:flex-start',
-            'justify-content:center',
-            'padding:72px 16px 24px',
-            'box-sizing:border-box',
-            'font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif',
-            'color:#111827',
-        ].join(';');
-
-        const panel = document.createElement('section');
-        panel.setAttribute('role', 'dialog');
-        panel.setAttribute('aria-modal', 'true');
-        panel.style.cssText = [
-            'width:min(720px,100%)',
-            'max-height:calc(100vh - 96px)',
-            'overflow:auto',
-            'background:#fff',
-            'border:1px solid rgba(15,23,42,.12)',
-            'border-radius:10px',
-            'box-shadow:0 20px 50px rgba(15,23,42,.22)',
-        ].join(';');
-
-        const header = document.createElement('div');
-        header.style.cssText = [
-            'position:sticky',
-            'top:0',
-            'display:flex',
-            'align-items:center',
-            'justify-content:space-between',
-            'gap:16px',
-            'padding:16px 18px',
-            'background:#fff',
-            'border-bottom:1px solid #e5e7eb',
-        ].join(';');
-
-        const title = document.createElement('h2');
-        title.textContent = 'MediaSpeedToggle 状态与配置';
-        title.style.cssText = [
-            'margin:0',
-            'font-size:16px',
-            'line-height:1.4',
-            'font-weight:650',
-        ].join(';');
-
-        const closeButton = document.createElement('button');
-        closeButton.type = 'button';
-        closeButton.textContent = '关闭';
-        closeButton.style.cssText = [
-            'border:1px solid #d1d5db',
-            'background:#fff',
-            'color:#111827',
-            'border-radius:6px',
-            'padding:5px 10px',
-            'font-size:13px',
-            'line-height:1.4',
-            'cursor:pointer',
-        ].join(';');
-        closeButton.addEventListener('click', closeInfoOverlay);
-
-        header.append(title, closeButton);
-        panel.appendChild(header);
-
-        const body = document.createElement('div');
-        body.style.cssText = [
-            'display:grid',
-            'gap:14px',
-            'padding:16px 18px 18px',
-            'font-size:13px',
-            'line-height:1.55',
-        ].join(';');
-
-        renderInfoContent(body);
-
-        panel.appendChild(body);
-        overlay.appendChild(panel);
-        overlay.addEventListener('click', (event) => {
-            if (event.target === overlay) closeInfoOverlay();
-        });
-
-        overlayKeydownHandler = (event) => {
-            if (event.key === 'Escape') closeInfoOverlay();
-        };
-        document.addEventListener('keydown', overlayKeydownHandler, true);
-        document.documentElement.appendChild(overlay);
-    }
-
-    function closeInfoOverlay() {
-        document.getElementById(OVERLAY_ID)?.remove();
-        if (overlayKeydownHandler) {
-            document.removeEventListener(
-                'keydown',
-                overlayKeydownHandler,
-                true,
-            );
-            overlayKeydownHandler = null;
-        }
-    }
-
-    function renderInfoContent(container) {
-        const decision = resolveRate();
-        appendSection(container, '本页状态', [
-            ['当前速度', formatRate(decision.rate)],
-            ['当前来源', formatDecisionSource(decision)],
-            ['命中规则', decision.reason || decision.rule],
-            ['规则 ID', decision.rule],
-            ['覆盖关系', explainDecision(decision)],
-            ['本页临时', formatOptionalRate(decision.pageOverrideRate)],
-            [
-                '页面规则',
-                decision.source === '页面规则' ? decision.reason : '未命中',
-            ],
-        ]);
-        appendSection(container, '站点状态', [
-            ['当前站点', decision.siteKey],
-            ['源码站点默认', formatOptionalRate(decision.siteRate)],
-            ['站点默认配置', formatSiteDefaults()],
-        ]);
-        appendSection(container, '全局状态', [
-            ['源码默认', formatRate(decision.defaultRate)],
-            ['快捷键', isMac ? 'Cmd+E' : 'Ctrl+E'],
-            [
-                '速度档位',
-                `${formatRate(RATE_NORMAL)} / ${formatRate(RATE_FAST)}`,
-            ],
-            ['优先级', '本页临时 > 页面规则 > 源码站点默认 > 源码默认'],
-            ['持久化状态', '无'],
-        ]);
-        appendSection(container, '页面规则', [
-            ['YouTube 直播', '/live/、直播媒体、直播元信息或可见直播标记'],
-            ['B 站直播', 'hostname 为 live.bilibili.com'],
-            ['B 站视频 tag 选择器', BILIBILI_VIDEO_TAG_SELECTOR],
-            [
-                'B 站 ASMR tag',
-                `包含 ASMR 或 ${formatList(Array.from(BILIBILI_ASMR_TAGS))}`,
-            ],
-            ['B 站音乐 tag', formatList(Array.from(BILIBILI_MUSIC_TAGS))],
-            ['B 站舞蹈 tag', formatList(Array.from(BILIBILI_DANCE_TAGS))],
-        ]);
-
-        if (isBilibiliHost()) {
-            appendSection(container, 'B 站 tag 诊断', [
-                ['页面 tag', formatList(collectBilibiliVideoTags())],
-                ['命中 tag', formatList(decision.matchedTags || [])],
-                ['tag 选择器', BILIBILI_VIDEO_TAG_SELECTOR],
-            ]);
-        }
-    }
-
-    function appendSection(container, title, rows) {
-        const section = document.createElement('section');
-        section.style.cssText = [
-            'border:1px solid #e5e7eb',
-            'border-radius:8px',
-            'overflow:hidden',
-            'background:#fff',
-        ].join(';');
-
-        const heading = document.createElement('h3');
-        heading.textContent = title;
-        heading.style.cssText = [
-            'margin:0',
-            'padding:9px 12px',
-            'font-size:13px',
-            'line-height:1.4',
-            'font-weight:650',
-            'background:#f9fafb',
-            'border-bottom:1px solid #e5e7eb',
-        ].join(';');
-        section.appendChild(heading);
-
-        rows.forEach(([label, value]) => {
-            const row = document.createElement('div');
-            row.style.cssText = [
-                'display:grid',
-                'grid-template-columns:minmax(112px,160px) 1fr',
-                'gap:12px',
-                'padding:8px 12px',
-                'border-top:1px solid #f3f4f6',
-            ].join(';');
-
-            const labelEl = document.createElement('div');
-            labelEl.textContent = label;
-            labelEl.style.cssText = 'color:#6b7280;min-width:0';
-
-            const valueEl = document.createElement('div');
-            valueEl.textContent = String(value);
-            valueEl.style.cssText = [
-                'color:#111827',
-                'min-width:0',
-                'overflow-wrap:anywhere',
-                'word-break:break-word',
-            ].join(';');
-
-            row.append(labelEl, valueEl);
-            section.appendChild(row);
-        });
-
-        container.appendChild(section);
-    }
-
-    function formatDecisionSource(decision) {
-        return `${decision.source}${decision.reason ? `：${decision.reason}` : ''}`;
-    }
-
-    function formatOptionalRate(rate) {
-        return rate === null || rate === undefined
-            ? '未设置'
-            : formatRate(rate);
-    }
-
-    function formatList(items) {
-        return items.length > 0 ? items.join('、') : '无';
-    }
-
-    function formatSiteDefaults() {
-        const entries = Object.entries(SITE_DEFAULT_RATES);
-        if (entries.length === 0) return '无';
-
-        return entries
-            .map(([site, rate]) => `${site}: ${formatRate(rate)}`)
-            .join('、');
-    }
-
-    function explainDecision(decision) {
-        if (decision.rule === 'page-override') {
-            return '本页临时速度优先于页面规则、源码站点默认和源码默认';
-        }
-        if (decision.source === '页面规则') {
-            return `${decision.reason} 命中，优先于源码站点默认和源码默认`;
-        }
-        if (decision.rule === 'source-site-default') {
-            return '未命中本页临时速度或页面规则，使用源码站点默认';
-        }
-        return '未命中本页临时速度、页面规则或源码站点默认，使用源码默认';
-    }
-
-    function showToast(message) {
-        let el = document.getElementById('dcjanus-media-speed-toast');
-        if (!el) {
-            el = document.createElement('div');
-            el.id = 'dcjanus-media-speed-toast';
-            el.style.cssText = [
-                'position:fixed',
-                'right:16px',
-                'top:16px',
-                'z-index:2147483647',
-                'background:rgba(0,0,0,.78)',
-                'color:#fff',
-                'padding:8px 12px',
-                'border-radius:8px',
-                'font-size:13px',
-                'line-height:1.4',
-                'font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif',
-                'pointer-events:none',
-                'opacity:0',
-                'transform:translateY(-4px)',
-                'transition:opacity .15s ease, transform .15s ease',
-            ].join(';');
-            document.documentElement.appendChild(el);
-        }
-
-        el.textContent = message;
-        el.style.opacity = '1';
-        el.style.transform = 'translateY(0)';
-
-        clearTimeout(toastTimer);
-        toastTimer = window.setTimeout(() => {
-            el.style.opacity = '0';
-            el.style.transform = 'translateY(-4px)';
-        }, 1200);
-    }
-
-    function setMediaRate(media) {
-        if (!(media instanceof HTMLMediaElement)) return;
-        const rate = currentRate();
-
-        if (
-            sameRate(media.playbackRate, rate) &&
-            sameRate(media.defaultPlaybackRate, rate)
-        ) {
-            return;
-        }
-
-        applyingMap.set(media, true);
-        try {
-            media.defaultPlaybackRate = rate;
-            media.playbackRate = rate;
-        } finally {
-            applyingMap.set(media, false);
-        }
-    }
-
-    function recordExternalRate(media) {
-        if (!(media instanceof HTMLMediaElement)) return;
-        if (applyingMap.get(media)) return;
-
-        const externalRate = normalizeRate(media.playbackRate);
-        if (externalRate === null) return;
-        if (sameRate(externalRate, currentRate())) return;
-
-        pageOverrideRate = externalRate;
-        refreshMenu();
-        scheduleApplyAll();
-    }
-
-    function bindMedia(media) {
-        if (!(media instanceof HTMLMediaElement) || boundMedia.has(media))
-            return;
-        boundMedia.add(media);
-
-        media.addEventListener(
-            'ratechange',
-            () => recordExternalRate(media),
-            true,
-        );
-
-        media.addEventListener(
-            'loadedmetadata',
-            () => setMediaRate(media),
-            true,
-        );
-        media.addEventListener('play', () => setMediaRate(media), true);
-    }
-
-    function applyAllRates() {
-        document.querySelectorAll('video, audio').forEach((media) => {
-            bindMedia(media);
-            setMediaRate(media);
-        });
-    }
-
-    function applyRatesForNode(node) {
-        let handled = false;
-
-        if (node instanceof HTMLMediaElement) {
-            bindMedia(node);
-            setMediaRate(node);
-            return true;
-        }
-
-        if (!(node instanceof Element || node instanceof DocumentFragment))
-            return false;
-
-        node.querySelectorAll('video, audio').forEach((media) => {
-            bindMedia(media);
-            setMediaRate(media);
-            handled = true;
-        });
-
-        return handled;
-    }
-
-    function scheduleApplyAll() {
-        if (pendingApply) return;
-        pendingApply = window.setTimeout(() => {
-            pendingApply = 0;
-            applyAllRates();
-            refreshMenu();
-        }, REAPPLY_DEBOUNCE_MS);
-    }
-
-    function mayAffectPageRule(node) {
-        if (!(node instanceof Element || node instanceof DocumentFragment))
-            return false;
-
-        if (
-            node instanceof Element &&
-            (node.matches(BILIBILI_VIDEO_TAG_SELECTOR) ||
-                node.matches('.ytp-live, .ytp-live-badge') ||
-                node.matches('meta[itemprop="isLiveBroadcast"]'))
-        ) {
-            return true;
-        }
-
-        return Boolean(
-            node.querySelector(
-                [
-                    BILIBILI_VIDEO_TAG_SELECTOR,
-                    '.ytp-live',
-                    '.ytp-live-badge',
-                    'meta[itemprop="isLiveBroadcast"]',
-                ].join(','),
-            ),
-        );
-    }
-
-    function isEditingTarget(target) {
-        if (!(target instanceof HTMLElement)) return false;
-        if (target.isContentEditable) return true;
-        const tag = target.tagName;
-        return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-    }
-
-    function handleShortcut(event) {
-        if (isEditingTarget(event.target)) return;
-
-        const keyOk = event.code === 'KeyE';
-        if (!keyOk) return;
-
-        const macMatch =
-            isMac &&
-            event.metaKey &&
-            !event.ctrlKey &&
-            !event.altKey &&
-            !event.shiftKey;
-        const winMatch =
-            !isMac &&
-            event.ctrlKey &&
-            !event.metaKey &&
-            !event.altKey &&
-            !event.shiftKey;
-
-        if (!macMatch && !winMatch) return;
-
-        event.preventDefault();
-        event.stopPropagation();
-
-        const nextRate = sameRate(currentRate(), RATE_FAST)
-            ? RATE_NORMAL
-            : RATE_FAST;
-        pageOverrideRate = nextRate;
-        applyAllRates();
-        refreshMenu();
-        showToast(`速度：${formatRate(currentRate())}（本页临时）`);
-    }
-
-    function setupNavigationHooks() {
-        const checkUrlChanged = () => {
-            if (location.href === lastUrl) return;
-            lastUrl = location.href;
-            pageOverrideRate = null;
-            refreshMenu();
-            scheduleApplyAll();
-        };
-
-        const wrapHistory = (methodName) => {
-            const original = history[methodName];
-            history[methodName] = function wrappedHistoryMethod(...args) {
-                try {
-                    const result = original.apply(this, args);
-                    queueMicrotask(checkUrlChanged);
-                    return result;
-                } catch (error) {
-                    queueMicrotask(checkUrlChanged);
-                    console.error(
-                        '[MediaSpeedToggle] history wrapper failed:',
-                        error,
-                    );
-                    throw error;
-                }
-            };
-        };
-
-        wrapHistory('pushState');
-        wrapHistory('replaceState');
-        window.addEventListener('popstate', checkUrlChanged, true);
-
-        const rootObserver = new MutationObserver((mutations) => {
-            let changed = false;
-            let ruleMayChange = false;
-            mutations.forEach((mutation) => {
-                mutation.addedNodes.forEach((node) => {
-                    changed = applyRatesForNode(node) || changed;
-                    ruleMayChange = mayAffectPageRule(node) || ruleMayChange;
-                });
-            });
-            if (changed) lastIncrementalApplyAt = Date.now();
-            if (ruleMayChange) scheduleApplyAll();
-            checkUrlChanged();
-        });
-        rootObserver.observe(document.documentElement, {
-            childList: true,
-            subtree: true,
-        });
-    }
-
-    function start() {
-        window.addEventListener('keydown', handleShortcut, true);
-        setupNavigationHooks();
-
-        applyAllRates();
-        refreshMenu();
-
-        window.setInterval(() => {
-            if (document.hidden) return;
-            if (!document.querySelector('video, audio')) return;
-            if (Date.now() - lastIncrementalApplyAt < HEAL_INTERVAL_MS) return;
-            applyAllRates();
-        }, HEAL_INTERVAL_MS);
-    }
-
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', start, { once: true });
-    } else {
-        start();
-    }
+	// 参考实现（仅记录思路来源，当前脚本保持个人定制与最小功能）：
+	// - h5player: https://github.com/xxxily/h5player
+	// - Video Speed Controller: https://greasyfork.org/en/scripts/534111-video-speed-controller-control-speed-on-videos-in-any-website
+	// - All Media Speed: https://greasyfork.org/en/scripts/541300-all-media-speed
+	// - Universal Video Speed Adjuster: https://greasyfork.org/en/scripts/550693-universal-video-speed-adjuster
+
+	const RATE_NORMAL = 1;
+	const RATE_FAST = 3;
+	const DEFAULT_RATE = RATE_FAST;
+	const SITE_DEFAULT_RATES = Object.freeze({
+		// 'example.com': RATE_NORMAL,
+	});
+	const REAPPLY_DEBOUNCE_MS = 120;
+	const HEAL_INTERVAL_MS = 1500;
+	const OVERLAY_ID = "dcjanus-media-speed-overlay";
+	const BILIBILI_VIDEO_TAG_SELECTOR =
+		'.video-tag-container a.tag-link, a.tag-link[href*="from_source=video_tag"]';
+	const BILIBILI_ASMR_TAGS = new Set([
+		"助眠",
+		"催眠",
+		"耳语",
+		"触发音",
+		"采耳",
+		"耳搔",
+	]);
+	const BILIBILI_MUSIC_TAGS = new Set([
+		"音乐",
+		"音乐现场",
+		"音乐推荐",
+		"音乐综合",
+		"原创音乐",
+		"流行音乐",
+		"歌曲",
+		"音乐选集",
+		"听歌",
+		"翻唱",
+		"男声翻唱",
+		"女声翻唱",
+		"说唱",
+		"演奏",
+		"VOCALOID",
+		"VOCALOID·UTAU",
+		"UTAU",
+		"MV",
+		"华语MV",
+		"mv说唱",
+		"BGM",
+	]);
+	const BILIBILI_DANCE_TAGS = new Set([
+		"舞蹈",
+		"翻跳",
+		"舞蹈翻跳",
+		"舞蹈随拍",
+		"舞蹈挑战",
+		"热舞",
+		"抖舞",
+		"宅舞",
+		"街舞",
+		"中国舞",
+		"编舞",
+	]);
+
+	const isMac =
+		navigator.userAgentData?.platform === "macOS" ||
+		/\bMac(?:intosh)?\b/i.test(navigator.userAgent) ||
+		navigator.platform?.toUpperCase().includes("MAC");
+	let pageOverrideRate = null;
+	let lastUrl = location.href;
+	let pendingApply = 0;
+	let toastTimer = 0;
+	let lastIncrementalApplyAt = 0;
+	let menuCommandIds = [];
+	let lastMenuText = "";
+	let overlayKeydownHandler = null;
+
+	const applyingMap = new WeakMap();
+	const boundMedia = new WeakSet();
+
+	function currentRate() {
+		return resolveRate().rate;
+	}
+
+	function normalizeRate(rate) {
+		const numericRate = Number(rate);
+		if (!Number.isFinite(numericRate)) return null;
+		if (numericRate < 0.0625 || numericRate > 16) return null;
+		return Math.round(numericRate * 100) / 100;
+	}
+
+	function sameRate(a, b) {
+		return Math.abs(a - b) < 0.001;
+	}
+
+	function formatRate(rate) {
+		return `${Number(rate.toFixed(2))}x`;
+	}
+
+	function currentSiteKey() {
+		return location.hostname.replace(/^www\./, "");
+	}
+
+	function isTopWindow() {
+		return window.top === window.self;
+	}
+
+	function getSiteRate() {
+		const siteKey = currentSiteKey();
+		return Object.hasOwn(SITE_DEFAULT_RATES, siteKey)
+			? SITE_DEFAULT_RATES[siteKey]
+			: null;
+	}
+
+	function detectPageRule() {
+		if (isYouTubeLivePage()) {
+			return {
+				rate: RATE_NORMAL,
+				source: "页面规则",
+				reason: "YouTube 直播",
+				rule: "youtube-live",
+			};
+		}
+
+		if (isBilibiliLivePage()) {
+			return {
+				rate: RATE_NORMAL,
+				source: "页面规则",
+				reason: "B 站直播",
+				rule: "bilibili-live-host",
+			};
+		}
+
+		const bilibiliTagRule = detectBilibiliTagRule();
+		if (bilibiliTagRule) return bilibiliTagRule;
+
+		return null;
+	}
+
+	function resolveRate() {
+		const siteKey = currentSiteKey();
+		const siteRate = getSiteRate();
+		const base = {
+			siteKey,
+			siteRate,
+			defaultRate: DEFAULT_RATE,
+			pageOverrideRate,
+		};
+
+		if (pageOverrideRate !== null) {
+			return {
+				...base,
+				rate: pageOverrideRate,
+				source: "本页临时",
+				reason: null,
+				rule: "page-override",
+			};
+		}
+
+		const pageRule = detectPageRule();
+		if (pageRule) return { ...base, ...pageRule };
+
+		if (siteRate !== null) {
+			return {
+				...base,
+				rate: siteRate,
+				source: "源码站点默认",
+				reason: siteKey,
+				rule: "source-site-default",
+			};
+		}
+
+		return {
+			...base,
+			rate: DEFAULT_RATE,
+			source: "源码默认",
+			reason: null,
+			rule: "source-default",
+		};
+	}
+
+	function isYouTubeHost() {
+		return /(^|\.)youtube\.com$/i.test(location.hostname);
+	}
+
+	function isBilibiliHost() {
+		return /(^|\.)bilibili\.com$/i.test(location.hostname);
+	}
+
+	function isYouTubeLivePage() {
+		if (!isYouTubeHost()) return false;
+		if (location.pathname.startsWith("/live/")) return true;
+		if (hasLiveMedia()) return true;
+		if (
+			document.querySelector(
+				'meta[itemprop="isLiveBroadcast"][content="True"], meta[itemprop="isLiveBroadcast"][content="true"]',
+			)
+		) {
+			return true;
+		}
+
+		return hasVisibleLiveBadge(".ytp-live, .ytp-live-badge");
+	}
+
+	function hasLiveMedia() {
+		return Array.from(document.querySelectorAll("video")).some(
+			(media) => media.duration === Infinity,
+		);
+	}
+
+	function hasVisibleLiveBadge(selector) {
+		return Array.from(document.querySelectorAll(selector)).some((el) => {
+			const text = `${el.textContent || ""} ${
+				el.getAttribute("aria-label") || ""
+			}`;
+			if (!/(live|直播)/i.test(text)) return false;
+			const style = window.getComputedStyle(el);
+			if (
+				style.display === "none" ||
+				style.visibility === "hidden" ||
+				style.opacity === "0"
+			) {
+				return false;
+			}
+			return el.getClientRects().length > 0;
+		});
+	}
+
+	function isBilibiliLivePage() {
+		return /^live\.bilibili\.com$/i.test(location.hostname);
+	}
+
+	function detectBilibiliTagRule() {
+		if (!isBilibiliHost()) return false;
+
+		const pageTags = collectBilibiliVideoTags();
+		const asmrTags = pageTags.filter(isBilibiliAsmrTag);
+		if (asmrTags.length > 0) {
+			return {
+				rate: RATE_NORMAL,
+				source: "页面规则",
+				reason: "B 站 ASMR",
+				rule: "bilibili-asmr-tags",
+				pageTags,
+				matchedTags: asmrTags,
+			};
+		}
+
+		const musicTags = pageTags.filter((tag) => BILIBILI_MUSIC_TAGS.has(tag));
+		if (musicTags.length > 0) {
+			return {
+				rate: RATE_NORMAL,
+				source: "页面规则",
+				reason: "B 站音乐",
+				rule: "bilibili-music-tags",
+				pageTags,
+				matchedTags: musicTags,
+			};
+		}
+
+		const danceTags = pageTags.filter((tag) => BILIBILI_DANCE_TAGS.has(tag));
+		if (danceTags.length > 0) {
+			return {
+				rate: RATE_NORMAL,
+				source: "页面规则",
+				reason: "B 站舞蹈",
+				rule: "bilibili-dance-tags",
+				pageTags,
+				matchedTags: danceTags,
+			};
+		}
+
+		return null;
+	}
+
+	function isBilibiliAsmrTag(tag) {
+		return tag.toLowerCase().includes("asmr") || BILIBILI_ASMR_TAGS.has(tag);
+	}
+
+	function collectBilibiliVideoTags() {
+		const domTags = Array.from(
+			document.querySelectorAll(BILIBILI_VIDEO_TAG_SELECTOR),
+			(node) => normalizeBilibiliTag(node.textContent || ""),
+		).filter(Boolean);
+		const metaTags = collectBilibiliMetaTags();
+
+		return Array.from(new Set([...domTags, ...metaTags]));
+	}
+
+	function collectBilibiliMetaTags() {
+		const keywords = document.querySelector(
+			'meta[itemprop="keywords"], meta[name="keywords"]',
+		)?.content;
+		if (!keywords) return [];
+
+		return keywords.split(",").map(normalizeBilibiliTag).filter(Boolean);
+	}
+
+	function normalizeBilibiliTag(tag) {
+		return tag.trim().replace(/^#+|#+$/g, "");
+	}
+
+	function refreshMenu() {
+		if (!isTopWindow()) return;
+
+		const menuText = formatMenuText(resolveRate());
+		if (menuText === lastMenuText && menuCommandIds.length > 0) return;
+
+		unregisterMenuCommands();
+		menuCommandIds.push(
+			GM_registerMenuCommand(
+				menuText,
+				() => {
+					showInfoOverlay();
+				},
+				{
+					title: "查看 MediaSpeedToggle 状态与配置",
+				},
+			),
+		);
+		lastMenuText = menuText;
+	}
+
+	function unregisterMenuCommands() {
+		menuCommandIds.forEach((id) => {
+			try {
+				GM_unregisterMenuCommand(id);
+			} catch (error) {
+				console.warn(
+					"[MediaSpeedToggle] failed to unregister menu command:",
+					error,
+				);
+			}
+		});
+		menuCommandIds = [];
+	}
+
+	function formatMenuText(decision) {
+		return `状态与配置：${formatRate(decision.rate)}（${formatShortReason(decision)}）`;
+	}
+
+	function formatShortReason(decision) {
+		if (decision.reason) return decision.reason;
+
+		if (decision.rule === "page-override") return "本页临时";
+		if (decision.rule === "source-site-default") return "站点默认";
+		return "源码默认";
+	}
+
+	function showInfoOverlay() {
+		closeInfoOverlay();
+
+		const overlay = document.createElement("div");
+		overlay.id = OVERLAY_ID;
+		overlay.style.cssText = [
+			"position:fixed",
+			"inset:0",
+			"z-index:2147483647",
+			"background:rgba(15,23,42,.42)",
+			"display:flex",
+			"align-items:flex-start",
+			"justify-content:center",
+			"padding:72px 16px 24px",
+			"box-sizing:border-box",
+			"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif",
+			"color:#111827",
+		].join(";");
+
+		const panel = document.createElement("section");
+		panel.setAttribute("role", "dialog");
+		panel.setAttribute("aria-modal", "true");
+		panel.style.cssText = [
+			"width:min(720px,100%)",
+			"max-height:calc(100vh - 96px)",
+			"overflow:auto",
+			"background:#fff",
+			"border:1px solid rgba(15,23,42,.12)",
+			"border-radius:10px",
+			"box-shadow:0 20px 50px rgba(15,23,42,.22)",
+		].join(";");
+
+		const header = document.createElement("div");
+		header.style.cssText = [
+			"position:sticky",
+			"top:0",
+			"display:flex",
+			"align-items:center",
+			"justify-content:space-between",
+			"gap:16px",
+			"padding:16px 18px",
+			"background:#fff",
+			"border-bottom:1px solid #e5e7eb",
+		].join(";");
+
+		const title = document.createElement("h2");
+		title.textContent = "MediaSpeedToggle 状态与配置";
+		title.style.cssText = [
+			"margin:0",
+			"font-size:16px",
+			"line-height:1.4",
+			"font-weight:650",
+		].join(";");
+
+		const closeButton = document.createElement("button");
+		closeButton.type = "button";
+		closeButton.textContent = "关闭";
+		closeButton.style.cssText = [
+			"border:1px solid #d1d5db",
+			"background:#fff",
+			"color:#111827",
+			"border-radius:6px",
+			"padding:5px 10px",
+			"font-size:13px",
+			"line-height:1.4",
+			"cursor:pointer",
+		].join(";");
+		closeButton.addEventListener("click", closeInfoOverlay);
+
+		header.append(title, closeButton);
+		panel.appendChild(header);
+
+		const body = document.createElement("div");
+		body.style.cssText = [
+			"display:grid",
+			"gap:14px",
+			"padding:16px 18px 18px",
+			"font-size:13px",
+			"line-height:1.55",
+		].join(";");
+
+		renderInfoContent(body);
+
+		panel.appendChild(body);
+		overlay.appendChild(panel);
+		overlay.addEventListener("click", (event) => {
+			if (event.target === overlay) closeInfoOverlay();
+		});
+
+		overlayKeydownHandler = (event) => {
+			if (event.key === "Escape") closeInfoOverlay();
+		};
+		document.addEventListener("keydown", overlayKeydownHandler, true);
+		document.documentElement.appendChild(overlay);
+	}
+
+	function closeInfoOverlay() {
+		document.getElementById(OVERLAY_ID)?.remove();
+		if (overlayKeydownHandler) {
+			document.removeEventListener("keydown", overlayKeydownHandler, true);
+			overlayKeydownHandler = null;
+		}
+	}
+
+	function renderInfoContent(container) {
+		const decision = resolveRate();
+		appendSection(container, "本页状态", [
+			["当前速度", formatRate(decision.rate)],
+			["当前来源", formatDecisionSource(decision)],
+			["命中规则", decision.reason || decision.rule],
+			["规则 ID", decision.rule],
+			["覆盖关系", explainDecision(decision)],
+			["本页临时", formatOptionalRate(decision.pageOverrideRate)],
+			["页面规则", decision.source === "页面规则" ? decision.reason : "未命中"],
+		]);
+		appendSection(container, "站点状态", [
+			["当前站点", decision.siteKey],
+			["源码站点默认", formatOptionalRate(decision.siteRate)],
+			["站点默认配置", formatSiteDefaults()],
+		]);
+		appendSection(container, "全局状态", [
+			["源码默认", formatRate(decision.defaultRate)],
+			["快捷键", isMac ? "Cmd+E" : "Ctrl+E"],
+			["速度档位", `${formatRate(RATE_NORMAL)} / ${formatRate(RATE_FAST)}`],
+			["优先级", "本页临时 > 页面规则 > 源码站点默认 > 源码默认"],
+			["持久化状态", "无"],
+		]);
+		appendSection(container, "页面规则", [
+			["YouTube 直播", "/live/、直播媒体、直播元信息或可见直播标记"],
+			["B 站直播", "hostname 为 live.bilibili.com"],
+			["B 站视频 tag 选择器", BILIBILI_VIDEO_TAG_SELECTOR],
+			[
+				"B 站 ASMR tag",
+				`包含 ASMR 或 ${formatList(Array.from(BILIBILI_ASMR_TAGS))}`,
+			],
+			["B 站音乐 tag", formatList(Array.from(BILIBILI_MUSIC_TAGS))],
+			["B 站舞蹈 tag", formatList(Array.from(BILIBILI_DANCE_TAGS))],
+		]);
+
+		if (isBilibiliHost()) {
+			appendSection(container, "B 站 tag 诊断", [
+				["页面 tag", formatList(collectBilibiliVideoTags())],
+				["命中 tag", formatList(decision.matchedTags || [])],
+				["tag 选择器", BILIBILI_VIDEO_TAG_SELECTOR],
+			]);
+		}
+	}
+
+	function appendSection(container, title, rows) {
+		const section = document.createElement("section");
+		section.style.cssText = [
+			"border:1px solid #e5e7eb",
+			"border-radius:8px",
+			"overflow:hidden",
+			"background:#fff",
+		].join(";");
+
+		const heading = document.createElement("h3");
+		heading.textContent = title;
+		heading.style.cssText = [
+			"margin:0",
+			"padding:9px 12px",
+			"font-size:13px",
+			"line-height:1.4",
+			"font-weight:650",
+			"background:#f9fafb",
+			"border-bottom:1px solid #e5e7eb",
+		].join(";");
+		section.appendChild(heading);
+
+		rows.forEach(([label, value]) => {
+			const row = document.createElement("div");
+			row.style.cssText = [
+				"display:grid",
+				"grid-template-columns:minmax(112px,160px) 1fr",
+				"gap:12px",
+				"padding:8px 12px",
+				"border-top:1px solid #f3f4f6",
+			].join(";");
+
+			const labelEl = document.createElement("div");
+			labelEl.textContent = label;
+			labelEl.style.cssText = "color:#6b7280;min-width:0";
+
+			const valueEl = document.createElement("div");
+			valueEl.textContent = String(value);
+			valueEl.style.cssText = [
+				"color:#111827",
+				"min-width:0",
+				"overflow-wrap:anywhere",
+				"word-break:break-word",
+			].join(";");
+
+			row.append(labelEl, valueEl);
+			section.appendChild(row);
+		});
+
+		container.appendChild(section);
+	}
+
+	function formatDecisionSource(decision) {
+		return `${decision.source}${decision.reason ? `：${decision.reason}` : ""}`;
+	}
+
+	function formatOptionalRate(rate) {
+		return rate === null || rate === undefined ? "未设置" : formatRate(rate);
+	}
+
+	function formatList(items) {
+		return items.length > 0 ? items.join("、") : "无";
+	}
+
+	function formatSiteDefaults() {
+		const entries = Object.entries(SITE_DEFAULT_RATES);
+		if (entries.length === 0) return "无";
+
+		return entries
+			.map(([site, rate]) => `${site}: ${formatRate(rate)}`)
+			.join("、");
+	}
+
+	function explainDecision(decision) {
+		if (decision.rule === "page-override") {
+			return "本页临时速度优先于页面规则、源码站点默认和源码默认";
+		}
+		if (decision.source === "页面规则") {
+			return `${decision.reason} 命中，优先于源码站点默认和源码默认`;
+		}
+		if (decision.rule === "source-site-default") {
+			return "未命中本页临时速度或页面规则，使用源码站点默认";
+		}
+		return "未命中本页临时速度、页面规则或源码站点默认，使用源码默认";
+	}
+
+	function showToast(message) {
+		let el = document.getElementById("dcjanus-media-speed-toast");
+		if (!el) {
+			el = document.createElement("div");
+			el.id = "dcjanus-media-speed-toast";
+			el.style.cssText = [
+				"position:fixed",
+				"right:16px",
+				"top:16px",
+				"z-index:2147483647",
+				"background:rgba(0,0,0,.78)",
+				"color:#fff",
+				"padding:8px 12px",
+				"border-radius:8px",
+				"font-size:13px",
+				"line-height:1.4",
+				"font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,sans-serif",
+				"pointer-events:none",
+				"opacity:0",
+				"transform:translateY(-4px)",
+				"transition:opacity .15s ease, transform .15s ease",
+			].join(";");
+			document.documentElement.appendChild(el);
+		}
+
+		el.textContent = message;
+		el.style.opacity = "1";
+		el.style.transform = "translateY(0)";
+
+		clearTimeout(toastTimer);
+		toastTimer = window.setTimeout(() => {
+			el.style.opacity = "0";
+			el.style.transform = "translateY(-4px)";
+		}, 1200);
+	}
+
+	function setMediaRate(media) {
+		if (!(media instanceof HTMLMediaElement)) return;
+		const rate = currentRate();
+
+		if (
+			sameRate(media.playbackRate, rate) &&
+			sameRate(media.defaultPlaybackRate, rate)
+		) {
+			return;
+		}
+
+		applyingMap.set(media, true);
+		try {
+			media.defaultPlaybackRate = rate;
+			media.playbackRate = rate;
+		} finally {
+			applyingMap.set(media, false);
+		}
+	}
+
+	function recordExternalRate(media) {
+		if (!(media instanceof HTMLMediaElement)) return;
+		if (applyingMap.get(media)) return;
+
+		const externalRate = normalizeRate(media.playbackRate);
+		if (externalRate === null) return;
+		if (sameRate(externalRate, currentRate())) return;
+
+		pageOverrideRate = externalRate;
+		refreshMenu();
+		scheduleApplyAll();
+	}
+
+	function bindMedia(media) {
+		if (!(media instanceof HTMLMediaElement) || boundMedia.has(media)) return;
+		boundMedia.add(media);
+
+		media.addEventListener("ratechange", () => recordExternalRate(media), true);
+
+		media.addEventListener("loadedmetadata", () => setMediaRate(media), true);
+		media.addEventListener("play", () => setMediaRate(media), true);
+	}
+
+	function applyAllRates() {
+		document.querySelectorAll("video, audio").forEach((media) => {
+			bindMedia(media);
+			setMediaRate(media);
+		});
+	}
+
+	function applyRatesForNode(node) {
+		let handled = false;
+
+		if (node instanceof HTMLMediaElement) {
+			bindMedia(node);
+			setMediaRate(node);
+			return true;
+		}
+
+		if (!(node instanceof Element || node instanceof DocumentFragment))
+			return false;
+
+		node.querySelectorAll("video, audio").forEach((media) => {
+			bindMedia(media);
+			setMediaRate(media);
+			handled = true;
+		});
+
+		return handled;
+	}
+
+	function scheduleApplyAll() {
+		if (pendingApply) return;
+		pendingApply = window.setTimeout(() => {
+			pendingApply = 0;
+			applyAllRates();
+			refreshMenu();
+		}, REAPPLY_DEBOUNCE_MS);
+	}
+
+	function mayAffectPageRule(node) {
+		if (!(node instanceof Element || node instanceof DocumentFragment))
+			return false;
+
+		if (
+			node instanceof Element &&
+			(node.matches(BILIBILI_VIDEO_TAG_SELECTOR) ||
+				node.matches(".ytp-live, .ytp-live-badge") ||
+				node.matches('meta[itemprop="isLiveBroadcast"]'))
+		) {
+			return true;
+		}
+
+		return Boolean(
+			node.querySelector(
+				[
+					BILIBILI_VIDEO_TAG_SELECTOR,
+					".ytp-live",
+					".ytp-live-badge",
+					'meta[itemprop="isLiveBroadcast"]',
+				].join(","),
+			),
+		);
+	}
+
+	function isEditingTarget(target) {
+		if (!(target instanceof HTMLElement)) return false;
+		if (target.isContentEditable) return true;
+		const tag = target.tagName;
+		return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+	}
+
+	function handleShortcut(event) {
+		if (isEditingTarget(event.target)) return;
+
+		const keyOk = event.code === "KeyE";
+		if (!keyOk) return;
+
+		const macMatch =
+			isMac &&
+			event.metaKey &&
+			!event.ctrlKey &&
+			!event.altKey &&
+			!event.shiftKey;
+		const winMatch =
+			!isMac &&
+			event.ctrlKey &&
+			!event.metaKey &&
+			!event.altKey &&
+			!event.shiftKey;
+
+		if (!macMatch && !winMatch) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		const nextRate = sameRate(currentRate(), RATE_FAST)
+			? RATE_NORMAL
+			: RATE_FAST;
+		pageOverrideRate = nextRate;
+		applyAllRates();
+		refreshMenu();
+		showToast(`速度：${formatRate(currentRate())}（本页临时）`);
+	}
+
+	function setupNavigationHooks() {
+		const checkUrlChanged = () => {
+			if (location.href === lastUrl) return;
+			lastUrl = location.href;
+			pageOverrideRate = null;
+			refreshMenu();
+			scheduleApplyAll();
+		};
+
+		const wrapHistory = (methodName) => {
+			const original = history[methodName];
+			history[methodName] = function wrappedHistoryMethod(...args) {
+				try {
+					const result = original.apply(this, args);
+					queueMicrotask(checkUrlChanged);
+					return result;
+				} catch (error) {
+					queueMicrotask(checkUrlChanged);
+					console.error("[MediaSpeedToggle] history wrapper failed:", error);
+					throw error;
+				}
+			};
+		};
+
+		wrapHistory("pushState");
+		wrapHistory("replaceState");
+		window.addEventListener("popstate", checkUrlChanged, true);
+
+		const rootObserver = new MutationObserver((mutations) => {
+			let changed = false;
+			let ruleMayChange = false;
+			mutations.forEach((mutation) => {
+				mutation.addedNodes.forEach((node) => {
+					changed = applyRatesForNode(node) || changed;
+					ruleMayChange = mayAffectPageRule(node) || ruleMayChange;
+				});
+			});
+			if (changed) lastIncrementalApplyAt = Date.now();
+			if (ruleMayChange) scheduleApplyAll();
+			checkUrlChanged();
+		});
+		rootObserver.observe(document.documentElement, {
+			childList: true,
+			subtree: true,
+		});
+	}
+
+	function start() {
+		window.addEventListener("keydown", handleShortcut, true);
+		setupNavigationHooks();
+
+		applyAllRates();
+		refreshMenu();
+
+		window.setInterval(() => {
+			if (document.hidden) return;
+			if (!document.querySelector("video, audio")) return;
+			if (Date.now() - lastIncrementalApplyAt < HEAL_INTERVAL_MS) return;
+			applyAllRates();
+		}, HEAL_INTERVAL_MS);
+	}
+
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", start, { once: true });
+	} else {
+		start();
+	}
 })();

--- a/scripts/MoviePlus.user.js
+++ b/scripts/MoviePlus.user.js
@@ -11,297 +11,281 @@
 // @version        20260504
 // @license        MIT
 // ==/UserScript==
-'use strict';
 
-const myScriptStyle = document.createElement('style');
+const myScriptStyle = document.createElement("style");
 myScriptStyle.innerHTML =
-    '@charset utf-8;.c-aside {margin-bottom: 30px}  .c-aside-body {*letter-spacing: normal}  .c-aside-body a {border-radius: 6px;box-sizing: border-box;color: #37A;display: inline-block;letter-spacing: normal;margin: 0 8px 8px 0;overflow: hidden;padding: 0 8px;text-align: center;text-overflow: ellipsis;white-space: nowrap;width: 82px}  .c-aside-body a:link, .c-aside-body a:visited {background-color: #f5f5f5;color: #37A}  .c-aside-body a:hover, .c-aside-body a:active {background-color: #e8e8e8;color: #37A}  .c-aside-body a.disabled {text-decoration: line-through}  .c-aside-body a.available {background-color: #5ccccc;color: #006363}  .c-aside-body a.available:hover, .c-aside-body a.available:active {background-color: #3cc}  .c-aside-body a.honse {background-color: #fff0f5;color: #006363}  .c-aside-body a.honse:hover, .c-aside-body a.honse:active {background-color: #3cc}  .c-aside-body a.sites_r0 {text-decoration: line-through}';
+	"@charset utf-8;.c-aside {margin-bottom: 30px}  .c-aside-body {*letter-spacing: normal}  .c-aside-body a {border-radius: 6px;box-sizing: border-box;color: #37A;display: inline-block;letter-spacing: normal;margin: 0 8px 8px 0;overflow: hidden;padding: 0 8px;text-align: center;text-overflow: ellipsis;white-space: nowrap;width: 82px}  .c-aside-body a:link, .c-aside-body a:visited {background-color: #f5f5f5;color: #37A}  .c-aside-body a:hover, .c-aside-body a:active {background-color: #e8e8e8;color: #37A}  .c-aside-body a.disabled {text-decoration: line-through}  .c-aside-body a.available {background-color: #5ccccc;color: #006363}  .c-aside-body a.available:hover, .c-aside-body a.available:active {background-color: #3cc}  .c-aside-body a.honse {background-color: #fff0f5;color: #006363}  .c-aside-body a.honse:hover, .c-aside-body a.honse:active {background-color: #3cc}  .c-aside-body a.sites_r0 {text-decoration: line-through}";
 myScriptStyle.innerHTML +=
-    ' .db-series-link, .db-series-link:link, .db-series-link:visited, .db-series-link:hover, .db-series-link:active { color: inherit !important; text-decoration: none !important; }';
-document.getElementsByTagName('head')[0].appendChild(myScriptStyle);
+	" .db-series-link, .db-series-link:link, .db-series-link:visited, .db-series-link:hover, .db-series-link:active { color: inherit !important; text-decoration: none !important; }";
+document.getElementsByTagName("head")[0].appendChild(myScriptStyle);
 const aside_html =
-    '<div class=c-aside > <h2><i class="">四字标题</i>· · · · · · </h2> <div class=c-aside-body  style="padding: 0 12px;"> <ul class=bs > </ul> </div> </div>';
+	'<div class=c-aside > <h2><i class="">四字标题</i>· · · · · · </h2> <div class=c-aside-body  style="padding: 0 12px;"> <ul class=bs > </ul> </div> </div>';
 
 const en_total_reg = /^[a-zA-Z\d\s-:·,/`~!@#$%^&*()_+<>?"{}.…;'[\]]+$/;
 const en_end_reg = /\s[a-zA-Z\d\s-:·,/`~!@#$%^&*()_+<>?"{}.…;'[\]]+$/;
 const cn_start_reg =
-    /^[\u4e00-\u9fa5a-zA-Z\d\s-：:·,，/`~!@#$%^&*()_+<>?"{}.…;'[\]！￥（—）；“”‘、|《。》？【】]+/;
+	/^[\u4e00-\u9fa5a-zA-Z\d\s-：:·,，/`~!@#$%^&*()_+<>?"{}.…;'[\]！￥（—）；“”‘、|《。》？【】]+/;
 const cn_total_reg =
-    /^[\u4e00-\u9fa5a-zA-Z\d\s-：:·,，/`~!@#$%^&*()_+<>?"{}.…;'[\]！￥（—）；“”‘、|《。》？【】]+$/;
+	/^[\u4e00-\u9fa5a-zA-Z\d\s-：:·,，/`~!@#$%^&*()_+<>?"{}.…;'[\]！￥（—）；“”‘、|《。》？【】]+$/;
 const symbol_delete_reg =
-    /[-：:·,，/`~!@#$%^&*()_+<>?"{}.…;[\]！￥（—）；“”‘、|《。》？【】]/g;
+	/[-：:·,，/`~!@#$%^&*()_+<>?"{}.…;[\]！￥（—）；“”‘、|《。》？【】]/g;
 
 function parseURL(url) {
-    let a;
-    a = document.createElement('a');
-    a.href = url;
-    return {
-        source: url,
-        protocol: a.protocol.replace(':', ''),
-        host: a.hostname,
-        port: a.port,
-        query: a.search,
-        params: (function () {
-            let i, len, ret, s, seg;
-            ret = {};
-            seg = a.search.replace(/^\?/, '').split('&');
-            len = seg.length;
-            i = 0;
-            s = void 0;
-            while (i < len) {
-                if (!seg[i]) {
-                    i++;
-                    continue;
-                }
-                s = seg[i].split('=');
-                ret[s[0]] = s[1];
-                i++;
-            }
-            return ret;
-        })(),
-        file: (a.pathname.match(/\/([^\/?#]+)$/i) || [, ''])[1],
-        hash: a.hash.replace('#', ''),
-        path: a.pathname.replace(/^([^\/])/, '/$1'),
-        relative: (a.href.match(/tps?:\/\/[^\/]+(.+)/) || [, ''])[1],
-        segments: a.pathname.replace(/^\//, '').split('/'),
-    };
+	let a;
+	a = document.createElement("a");
+	a.href = url;
+	return {
+		source: url,
+		protocol: a.protocol.replace(":", ""),
+		host: a.hostname,
+		port: a.port,
+		query: a.search,
+		params: (() => {
+			let i, len, ret, s, seg;
+			ret = {};
+			seg = a.search.replace(/^\?/, "").split("&");
+			len = seg.length;
+			i = 0;
+			s = void 0;
+			while (i < len) {
+				if (!seg[i]) {
+					i++;
+					continue;
+				}
+				s = seg[i].split("=");
+				ret[s[0]] = s[1];
+				i++;
+			}
+			return ret;
+		})(),
+		file: (a.pathname.match(/\/([^/?#]+)$/i) || [undefined, ""])[1],
+		hash: a.hash.replace("#", ""),
+		path: a.pathname.replace(/^([^/])/, "/$1"),
+		relative: (a.href.match(/tps?:\/\/[^/]+(.+)/) || [undefined, ""])[1],
+		segments: a.pathname.replace(/^\//, "").split("/"),
+	};
 }
 
-function update_bt_site(title, year, douban_ID, IMDb_ID, title_cn) {
-    let name, sites;
-    const siteList = document.querySelector('#content div.site-bt-body ul');
-    if (!siteList) return;
+function update_bt_site(title, year, _douban_ID, _IMDb_ID, title_cn) {
+	let name, sites;
+	const siteList = document.querySelector("#content div.site-bt-body ul");
+	if (!siteList) return;
 
-    title = title.trim();
-    const cnSearchKeyword = encodeURIComponent(
-        get_cn_site_search_keyword(title_cn, title),
-    );
-    sites = {
-        爱壹帆: 'https://www.yfsp.tv/search/' + cnSearchKeyword,
-        'BTDigg EN':
-            'https://www.btdig.com/search?q=' + title + ' ' + year + ' 1080p',
-        'BTDigg 中': 'https://www.btdig.com/search?q=' + title_cn,
-        'EXT.TO': 'https://ext.to/browse/?q=' + title,
-        独播库:
-            'https://www.dbku.tv/vodsearch/-------------.html?wd=' +
-            cnSearchKeyword,
-        动漫花园: 'https://dmhy.org/topics/list?keyword=' + title,
-    };
+	title = title.trim();
+	const cnSearchKeyword = encodeURIComponent(
+		get_cn_site_search_keyword(title_cn, title),
+	);
+	sites = {
+		爱壹帆: `https://www.yfsp.tv/search/${cnSearchKeyword}`,
+		"BTDigg EN": `https://www.btdig.com/search?q=${title} ${year} 1080p`,
+		"BTDigg 中": `https://www.btdig.com/search?q=${title_cn}`,
+		"EXT.TO": `https://ext.to/browse/?q=${title}`,
+		独播库: `https://www.dbku.tv/vodsearch/-------------.html?wd=${cnSearchKeyword}`,
+		动漫花园: `https://dmhy.org/topics/list?keyword=${title}`,
+	};
 
-    if (is_series(title)) {
-        sites['BTDigg EN'] =
-            'https://www.btdig.com/search?q=' + title + ' 1080p';
-    }
+	if (is_series(title)) {
+		sites["BTDigg EN"] = `https://www.btdig.com/search?q=${title} 1080p`;
+	}
 
-    for (name in sites) {
-        let link = parse_sites(name, sites);
-        siteList.append(link);
-    }
+	for (name in sites) {
+		const link = parse_sites(name, sites);
+		siteList.append(link);
+	}
 }
 
 function get_cn_site_search_keyword(title_cn, title) {
-    const keyword = title_cn.trim();
-    if (!keyword) return title;
-    if (!/[\u4e00-\u9fa5]/.test(keyword)) return keyword;
+	const keyword = title_cn.trim();
+	if (!keyword) return title;
+	if (!/[\u4e00-\u9fa5]/.test(keyword)) return keyword;
 
-    return keyword.replace(/\s+[a-zA-Z][\s\S]*$/, '').trim() || keyword;
+	return keyword.replace(/\s+[a-zA-Z][\s\S]*$/, "").trim() || keyword;
 }
 
 function update_sub_site(title, douban_ID, IMDb_ID) {
-    let name, sites;
-    const siteList = document.querySelector('#content div.site-sub-body ul');
-    if (!siteList) return;
+	let name, sites;
+	const siteList = document.querySelector("#content div.site-sub-body ul");
+	if (!siteList) return;
 
-    title = encodeURI(title);
+	title = encodeURI(title);
 
-    sites = {
-        SubHD: 'https://subhd.tv/d/' + douban_ID,
-        字幕库: 'https://srtku.com/search?q=' + IMDb_ID,
-        伪射手: 'https://assrt.net/sub/?searchword=' + title,
-    };
+	sites = {
+		SubHD: `https://subhd.tv/d/${douban_ID}`,
+		字幕库: `https://srtku.com/search?q=${IMDb_ID}`,
+		伪射手: `https://assrt.net/sub/?searchword=${title}`,
+	};
 
-    for (name in sites) {
-        let link = parse_sites(name, sites);
-        siteList.append(link);
-    }
+	for (name in sites) {
+		const link = parse_sites(name, sites);
+		siteList.append(link);
+	}
 }
 
 function parse_sites(name, sites) {
-    let link = sites[name],
-        link_parsed = parseURL(link);
-    const aTag = document.createElement('a');
-    aTag.href = link;
-    aTag.dataset.host = link_parsed.host;
-    aTag.target = '_blank';
-    aTag.rel = 'noopener noreferrer nofollow';
-    aTag.textContent = name;
+	const link = sites[name],
+		link_parsed = parseURL(link);
+	const aTag = document.createElement("a");
+	aTag.href = link;
+	aTag.dataset.host = link_parsed.host;
+	aTag.target = "_blank";
+	aTag.rel = "noopener noreferrer nofollow";
+	aTag.textContent = name;
 
-    return aTag;
+	return aTag;
 }
 
 function get_other_title_en(other_title) {
-    let other_title_en = '';
-    //获取第一个英文副标题
-    other_title.split('/').some((item) => {
-        if (en_total_reg.test(item)) {
-            other_title_en = item;
-            return true;
-        }
-    });
-    return other_title_en;
+	let other_title_en = "";
+	//获取第一个英文副标题
+	other_title.split("/").some((item) => {
+		if (en_total_reg.test(item)) {
+			other_title_en = item;
+			return true;
+		}
+		return false;
+	});
+	return other_title_en;
 }
 
 function is_series(name) {
-    return /S\d+$/.test(name);
+	return /S\d+$/.test(name);
 }
 
-function not_series_01(name) {
-    return /S\d+$/.test(name) & !name.endsWith('S01');
+function _not_series_01(name) {
+	return /S\d+$/.test(name) & !name.endsWith("S01");
 }
 
 function format_series_name(name) {
-    if (!/\sSeason\s\d+$/.test(name)) return name;
-    let name_arr = name.split('Season');
-    let series_id = name_arr.slice(-1)[0].trim().padStart(2, '0');
-    return name_arr[0] + 'S' + series_id;
+	if (!/\sSeason\s\d+$/.test(name)) return name;
+	const name_arr = name.split("Season");
+	const series_id = name_arr.slice(-1)[0].trim().padStart(2, "0");
+	return `${name_arr[0]}S${series_id}`;
 }
 
 function create_aside_section(title, sectionClass) {
-    const template = document.createElement('template');
-    template.innerHTML = aside_html.trim();
+	const template = document.createElement("template");
+	template.innerHTML = aside_html.trim();
 
-    const section = template.content.firstElementChild;
-    section.classList.add(sectionClass);
-    section
-        .querySelector('div.c-aside-body')
-        .classList.add(sectionClass + '-body');
-    section.querySelector('h2 i').textContent = title;
+	const section = template.content.firstElementChild;
+	section.classList.add(sectionClass);
+	section
+		.querySelector("div.c-aside-body")
+		.classList.add(`${sectionClass}-body`);
+	section.querySelector("h2 i").textContent = title;
 
-    return section;
+	return section;
 }
 
 function on_ready(callback) {
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', callback, { once: true });
-        return;
-    }
+	if (document.readyState === "loading") {
+		document.addEventListener("DOMContentLoaded", callback, { once: true });
+		return;
+	}
 
-    callback();
+	callback();
 }
 
 function main() {
-    const seBwhA = document.createElement('a');
-    seBwhA.id = 'seBwhA';
-    document.getElementsByTagName('html')[0].appendChild(seBwhA);
+	const seBwhA = document.createElement("a");
+	seBwhA.id = "seBwhA";
+	document.getElementsByTagName("html")[0].appendChild(seBwhA);
 
-    on_ready(() => {
-        const selector = document.querySelector('#content div.aside');
-        const h1_span = document.querySelectorAll('#content > h1 > span');
-        const info = document.querySelector('#info');
-        if (!selector || h1_span.length < 2 || !info) return;
+	on_ready(() => {
+		const selector = document.querySelector("#content div.aside");
+		const h1_span = document.querySelectorAll("#content > h1 > span");
+		const info = document.querySelector("#info");
+		if (!selector || h1_span.length < 2 || !info) return;
 
-        let site_sub = create_aside_section('字幕直达', 'site-sub');
-        site_sub.classList.add('name-offline');
-        selector.prepend(site_sub);
+		const site_sub = create_aside_section("字幕直达", "site-sub");
+		site_sub.classList.add("name-offline");
+		selector.prepend(site_sub);
 
-        let site_bt = create_aside_section('BT 搜索', 'site-bt');
-        site_bt.classList.add('site_bt');
-        selector.prepend(site_bt);
+		const site_bt = create_aside_section("BT 搜索", "site-bt");
+		site_bt.classList.add("site_bt");
+		selector.prepend(site_bt);
 
-        let title_cn,
-            title_en,
-            title_en_sub,
-            bt_title,
-            year,
-            douban_ID,
-            IMDb_ID;
+		let title_cn, title_en, title_en_sub, bt_title, year, douban_ID, IMDb_ID;
 
-        let title_all = h1_span[0].textContent;
+		const title_all = h1_span[0].textContent;
 
-        if (cn_total_reg.test(title_all)) {
-            //名称只有中英文时匹配英文——————————————
-            title_en = title_all.match(en_end_reg);
-            title_en = title_en ? title_en[0] : '';
-        }
+		if (cn_total_reg.test(title_all)) {
+			//名称只有中英文时匹配英文——————————————
+			title_en = title_all.match(en_end_reg);
+			title_en = title_en ? title_en[0] : "";
+		}
 
-        if (title_en) {
-            //有英文名时匹配中文——————————————
-            title_cn = title_en ? title_all.split(title_en)[0] : '';
-        } else {
-            //直接匹配中文——————————————
-            title_cn = title_all.match(cn_start_reg);
-            title_cn = title_cn ? title_cn[0] : '';
-        }
+		if (title_en) {
+			//有英文名时匹配中文——————————————
+			title_cn = title_en ? title_all.split(title_en)[0] : "";
+		} else {
+			//直接匹配中文——————————————
+			title_cn = title_all.match(cn_start_reg);
+			title_cn = title_cn ? title_cn[0] : "";
+		}
 
-        //检查名称——————————————
-        if (title_all.length !== (title_en + title_cn).length) {
-            title_cn = '';
-            let title_array = title_all.split(' ');
-            title_array.some((item) => {
-                if (!cn_total_reg.test(item)) return true;
-                title_cn += item + ' ';
-            });
+		//检查名称——————————————
+		if (title_all.length !== (title_en + title_cn).length) {
+			title_cn = "";
+			const title_array = title_all.split(" ");
+			title_array.some((item) => {
+				if (!cn_total_reg.test(item)) return true;
+				title_cn += `${item} `;
+				return false;
+			});
 
-            title_en = '';
-        }
+			title_en = "";
+		}
 
-        // 中文标题若包含“第x季”，将序列名替换为搜索链接
-        if (title_cn) {
-            const m = title_cn.match(
-                /^(.+?)\s*第([一二三四五六七八九十百\d]+)季/,
-            );
-            if (m && m[1]) {
-                const seriesName = m[1].trim();
-                const searchUrl =
-                    'https://search.douban.com/movie/subject_search?search_text=' +
-                    encodeURIComponent(seriesName);
-                const titleSpanEl = h1_span[0];
-                const escapeForRegExp = (s) =>
-                    s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                const leadingPattern = new RegExp(
-                    '^' + escapeForRegExp(seriesName),
-                );
-                titleSpanEl.innerHTML = titleSpanEl.innerHTML.replace(
-                    leadingPattern,
-                    `<a class="db-series-link" href="${searchUrl}" target="_blank" rel="noopener noreferrer nofollow" title="在豆瓣搜索「${seriesName}」的其他季">${seriesName}</a>`,
-                );
-            }
-        }
+		// 中文标题若包含“第x季”，将序列名替换为搜索链接
+		if (title_cn) {
+			const m = title_cn.match(/^(.+?)\s*第([一二三四五六七八九十百\d]+)季/);
+			if (m?.[1]) {
+				const seriesName = m[1].trim();
+				const searchUrl =
+					"https://search.douban.com/movie/subject_search?search_text=" +
+					encodeURIComponent(seriesName);
+				const titleSpanEl = h1_span[0];
+				const escapeForRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+				const leadingPattern = new RegExp(`^${escapeForRegExp(seriesName)}`);
+				titleSpanEl.innerHTML = titleSpanEl.innerHTML.replace(
+					leadingPattern,
+					`<a class="db-series-link" href="${searchUrl}" target="_blank" rel="noopener noreferrer nofollow" title="在豆瓣搜索「${seriesName}」的其他季">${seriesName}</a>`,
+				);
+			}
+		}
 
-        //解析info内容
-        let info_text = info.innerText,
-            info_map = {};
-        info_text.split('\n').forEach((line) => {
-            let index = line.indexOf(':');
-            if (index > 0)
-                info_map[line.slice(0, index).trim()] = line
-                    .slice(index + 1)
-                    .trim();
-        });
+		//解析info内容
+		const info_text = info.innerText,
+			info_map = {};
+		info_text.split("\n").forEach((line) => {
+			const index = line.indexOf(":");
+			if (index > 0)
+				info_map[line.slice(0, index).trim()] = line.slice(index + 1).trim();
+		});
 
-        //匹配备用英文名——————————————
-        title_en_sub = info_map['又名'];
-        title_en_sub = title_en_sub ? get_other_title_en(title_en_sub) : '';
+		//匹配备用英文名——————————————
+		title_en_sub = info_map.又名;
+		title_en_sub = title_en_sub ? get_other_title_en(title_en_sub) : "";
 
-        bt_title = title_en || title_en_sub || title_cn;
-        //规范的命名只保留英文字母
-        bt_title = bt_title
-            .replaceAll(symbol_delete_reg, ' ')
-            .replace("'", '')
-            .replace(/\s+/g, ' ')
-            .trim();
-        bt_title = format_series_name(bt_title);
+		bt_title = title_en || title_en_sub || title_cn;
+		//规范的命名只保留英文字母
+		bt_title = bt_title
+			.replaceAll(symbol_delete_reg, " ")
+			.replace("'", "")
+			.replace(/\s+/g, " ")
+			.trim();
+		bt_title = format_series_name(bt_title);
 
-        year = h1_span[1].textContent.substr(1, 4);
+		year = h1_span[1].textContent.substr(1, 4);
 
-        douban_ID = location.href.split('/')[4] || title_cn;
+		douban_ID = location.href.split("/")[4] || title_cn;
 
-        IMDb_ID = info_map['IMDb'];
-        IMDb_ID = IMDb_ID ? IMDb_ID : title_cn;
+		IMDb_ID = info_map.IMDb;
+		IMDb_ID = IMDb_ID ? IMDb_ID : title_cn;
 
-        update_bt_site(bt_title, year, douban_ID, IMDb_ID, title_cn);
-        update_sub_site(title_cn, douban_ID, IMDb_ID);
-    });
+		update_bt_site(bt_title, year, douban_ID, IMDb_ID, title_cn);
+		update_sub_site(title_cn, douban_ID, IMDb_ID);
+	});
 }
 
 main();

--- a/scripts/XTwitterImageWheel.user.js
+++ b/scripts/XTwitterImageWheel.user.js
@@ -11,60 +11,59 @@
 // @license      MIT
 // @grant        none
 // ==/UserScript==
-'use strict';
 
-const SCRIPT_NAME = 'XTwitterImageWheel';
+const SCRIPT_NAME = "XTwitterImageWheel";
 const COOLDOWN_MS = 250;
 const CAROUSEL_SELECTOR =
-    'div[role="dialog"] [aria-roledescription="carousel"]';
+	'div[role="dialog"] [aria-roledescription="carousel"]';
 
 let lastTs = 0;
 
 function isInCarousel() {
-    return Boolean(document.querySelector(CAROUSEL_SELECTOR));
+	return Boolean(document.querySelector(CAROUSEL_SELECTOR));
 }
 
 function dispatchArrow(key) {
-    const keyCode = key === 'ArrowLeft' ? 37 : 39;
-    const event = new KeyboardEvent('keydown', {
-        key,
-        code: key,
-        keyCode,
-        which: keyCode,
-        bubbles: true,
-        cancelable: true,
-    });
-    document.dispatchEvent(event);
+	const keyCode = key === "ArrowLeft" ? 37 : 39;
+	const event = new KeyboardEvent("keydown", {
+		key,
+		code: key,
+		keyCode,
+		which: keyCode,
+		bubbles: true,
+		cancelable: true,
+	});
+	document.dispatchEvent(event);
 }
 
 function handleWheel(event) {
-    if (!isInCarousel()) {
-        return;
-    }
+	if (!isInCarousel()) {
+		return;
+	}
 
-    if (event.deltaY === 0) {
-        return;
-    }
+	if (event.deltaY === 0) {
+		return;
+	}
 
-    const now = Date.now();
-    if (now - lastTs < COOLDOWN_MS) {
-        return;
-    }
-    lastTs = now;
+	const now = Date.now();
+	if (now - lastTs < COOLDOWN_MS) {
+		return;
+	}
+	lastTs = now;
 
-    if (event.deltaY < 0) {
-        dispatchArrow('ArrowLeft');
-    } else {
-        dispatchArrow('ArrowRight');
-    }
+	if (event.deltaY < 0) {
+		dispatchArrow("ArrowLeft");
+	} else {
+		dispatchArrow("ArrowRight");
+	}
 }
 
 function setup() {
-    document.addEventListener('wheel', handleWheel, { passive: true });
+	document.addEventListener("wheel", handleWheel, { passive: true });
 }
 
 try {
-    setup();
+	setup();
 } catch (error) {
-    console.error(`[${SCRIPT_NAME}]`, error);
+	console.error(`[${SCRIPT_NAME}]`, error);
 }


### PR DESCRIPTION
## Why

- 本地提交前检查和 CI 需要共用同一套入口，避免开发者手动维护多套检查命令。
- userscript 的格式与基础 lint 规则需要交给现代工具统一维护。

## What

- 新增 `prek.toml`，用 `prek` 统一运行通用文件检查和 Biome 检查。
- 新增最小 `biome.json`，移除不再使用的 Prettier 配置，并将 CI 切换到 `j178/prek-action@v2`。
- 将现有 userscript 按 Biome 默认规则格式化，并修复默认规则发现的 JS 问题。
- 在 `AGENTS.md` 和 `README.md` 约定 clone 后运行 `prek install`。
