### PR TITLE
feat(bilibili): 添加网页全屏快捷键

### DIFF
--- a/scripts/BiliBiliTweaks.user.js
+++ b/scripts/BiliBiliTweaks.user.js
@@ -2,7 +2,7 @@
 // @name         DCjanus BiliBili Tweaks
 // @name:zh-CN   DCjanus B 站增强
 // @namespace    https://github.com/dcjanus/userscripts
-// @version      20260512
+// @version      20260705
 // @description  useful tweaks for bilibili.com
 // @author       kookxiang, DCjanus
 // @match        https://*.bilibili.com/*
@@ -385,6 +385,56 @@ if (
 			return open.apply(this, args);
 		};
 	})(unsafeWindow.XMLHttpRequest.prototype.open);
+}
+
+// 视频页按 G 切换网页全屏
+if (
+	location.href.startsWith("https://www.bilibili.com/video/") ||
+	location.href.startsWith("https://www.bilibili.com/bangumi/play/")
+) {
+	function isEditableTarget(target) {
+		return (
+			typeof target?.closest === "function" &&
+			!!target.closest(
+				'input, textarea, select, [contenteditable=""], [contenteditable="true"], [role="textbox"]',
+			)
+		);
+	}
+
+	function findWebFullscreenButton() {
+		return Array.from(document.querySelectorAll(".bpx-player-ctrl-web")).find(
+			(button) => {
+				const rect = button.getBoundingClientRect();
+				return rect.width > 0 && rect.height > 0;
+			},
+		);
+	}
+
+	document.addEventListener(
+		"keydown",
+		(e) => {
+			if (
+				e.key.toLowerCase() !== "g" ||
+				e.altKey ||
+				e.ctrlKey ||
+				e.metaKey ||
+				e.shiftKey ||
+				e.repeat ||
+				e.isComposing ||
+				isEditableTarget(e.target)
+			) {
+				return;
+			}
+
+			const webFullscreenButton = findWebFullscreenButton();
+			if (!webFullscreenButton) return;
+
+			e.preventDefault();
+			e.stopImmediatePropagation();
+			webFullscreenButton.click();
+		},
+		true,
+	);
 }
 
 // 真·原画直播


### PR DESCRIPTION
## Why

- B 站视频页的网页全屏入口需要点播放器按钮，鼠标操作不够顺手。
- `G` 在左手区域，紧邻 `F`，适合作为网页全屏单键入口。

## What

- 为 B 站视频页和番剧播放页添加 `G` 单键切换网页全屏。
- 触发时复用播放器自己的 `.bpx-player-ctrl-web` 按钮，不重写网页全屏逻辑。
- 在输入框、弹幕输入、可编辑区域、组合键和长按重复触发时忽略该快捷键。
