### PR TITLE
fix(bilibili): 修正全屏横向滚轮为进度调整

### DIFF
--- a/scripts/BiliBiliTweaks.user.js
+++ b/scripts/BiliBiliTweaks.user.js
@@ -2,7 +2,7 @@
 // @name         DCjanus BiliBili Tweaks
 // @name:zh-CN   DCjanus B 站增强
 // @namespace    https://github.com/dcjanus/userscripts
-// @version      20260705
+// @version      20260707
 // @description  useful tweaks for bilibili.com
 // @author       kookxiang, DCjanus
 // @match        https://*.bilibili.com/*
@@ -392,6 +392,10 @@ if (
 	location.href.startsWith("https://www.bilibili.com/video/") ||
 	location.href.startsWith("https://www.bilibili.com/bangumi/play/")
 ) {
+	const PLAYER_HORIZONTAL_WHEEL_SEEK_COOLDOWN_MS = 250;
+	const PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS = 5;
+	let lastPlayerHorizontalWheelSeekAt = 0;
+
 	function isEditableTarget(target) {
 		return (
 			typeof target?.closest === "function" &&
@@ -408,6 +412,39 @@ if (
 				return rect.width > 0 && rect.height > 0;
 			},
 		);
+	}
+
+	function isPlayerFullscreen() {
+		if (document.fullscreenElement) return true;
+		return !!document.querySelector(
+			[
+				".bpx-player-container[data-screen='full']",
+				".bpx-player-container[data-screen='fullscreen']",
+				".bpx-player-container.bpx-state-fullscreen",
+				".bpx-player-container.bpx-player-fullscreen",
+				"#bilibili-player.mode-fullscreen",
+			].join(","),
+		);
+	}
+
+	function findPlayerVideo() {
+		return (
+			document.fullscreenElement?.querySelector?.("video") ||
+			document.querySelector("#bilibili-player video") ||
+			document.querySelector(".bpx-player-container video") ||
+			document.querySelector("video")
+		);
+	}
+
+	function seekPlayerVideo(seconds) {
+		const video = findPlayerVideo();
+		if (!video || !Number.isFinite(video.duration)) return false;
+
+		video.currentTime = Math.min(
+			Math.max(video.currentTime + seconds, 0),
+			video.duration,
+		);
+		return true;
 	}
 
 	document.addEventListener(
@@ -434,6 +471,33 @@ if (
 			webFullscreenButton.click();
 		},
 		true,
+	);
+
+	document.addEventListener(
+		"wheel",
+		(e) => {
+			if (!isPlayerFullscreen()) return;
+			if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+
+			e.preventDefault();
+			e.stopImmediatePropagation();
+
+			const now = Date.now();
+			if (
+				now - lastPlayerHorizontalWheelSeekAt <
+				PLAYER_HORIZONTAL_WHEEL_SEEK_COOLDOWN_MS
+			) {
+				return;
+			}
+			lastPlayerHorizontalWheelSeekAt = now;
+
+			seekPlayerVideo(
+				e.deltaX > 0
+					? PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS
+					: -PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS,
+			);
+		},
+		{ capture: true, passive: false },
 	);
 }
 


### PR DESCRIPTION
## Why

- B 站播放器全屏时会把横向滚轮当成音量调整。
- 横向滚轮一次操作会产生多次 `wheel` 事件，直接逐事件处理会导致跳转过多。

## What

- 在视频/番剧页全屏态拦截横向滚轮，并改为调整视频进度。
- 横向右滚快进 5 秒，横向左滚快退 5 秒。
- 增加 250ms 冷却窗口，避免一次滚轮操作触发多次进度跳转。
