### PR TITLE
fix(github-pr): 保留无法确认的 Viewed 状态

### DIFF
--- a/scripts/GitHubPrFileTreeReviewStats.user.js
+++ b/scripts/GitHubPrFileTreeReviewStats.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://github.com/*
 // @icon         https://github.com/favicon.ico
-// @version      20260601
+// @version      20260710
 // @license      MIT
 // @grant        none
 // @run-at       document-start
@@ -157,7 +157,7 @@ function getViewedState(file) {
 		'button[class*="MarkAsViewedButton"], button[aria-pressed][aria-label*="Viewed"], button[aria-pressed][aria-label*="viewed"]',
 	);
 	if (!button) {
-		return false;
+		return null;
 	}
 
 	const pressed = button.getAttribute("aria-pressed");
@@ -176,7 +176,7 @@ function getViewedState(file) {
 		return true;
 	}
 
-	return false;
+	return null;
 }
 
 function getHashFromLink(link) {


### PR DESCRIPTION
## 原因

无法识别文件的 Viewed 状态时，脚本会把它误判为未审阅并加粗显示。

## 改动

- 将无法确认的状态保留为未知值
- 仅在明确获得 Viewed 状态后调整文件树字重
