### PR TITLE
fix(github-date): 保留 relative-time 更新方法契约

### DIFF
--- a/scripts/GitHubDateNumeric.user.js
+++ b/scripts/GitHubDateNumeric.user.js
@@ -6,7 +6,7 @@
 // @author       DCjanus
 // @match        https://github.com/*
 // @icon         https://github.com/favicon.ico
-// @version      20260426
+// @version      20260710
 // @license      MIT
 // ==/UserScript==
 
@@ -148,9 +148,10 @@ function patchRelativeTimeElement(RelativeTimeElement) {
 	Object.defineProperty(proto, RELATIVE_TIME_PATCHED, {
 		value: true,
 	});
-	proto.update = function update() {
-		originalUpdate.call(this);
+	proto.update = function update(...args) {
+		const result = originalUpdate.apply(this, args);
 		renderRelativeTime(this);
+		return result;
 	};
 }
 


### PR DESCRIPTION
## 原因

脚本包装 `relative-time.update()` 时没有转发参数和返回值，可能在 GitHub 调整组件接口后改变原方法契约。

## 改动

- 将调用参数完整转发给原始 `update()`
- 保留并返回原方法的调用结果
