### PR TITLE
fix(bilibili)!: 移除全屏横向滚轮调进度

### DIFF
--- a/scripts/BiliBiliTweaks.user.js
+++ b/scripts/BiliBiliTweaks.user.js
@@ -2,7 +2,7 @@
 // @name         DCjanus BiliBili Tweaks
 // @name:zh-CN   DCjanus B 站增强
 // @namespace    https://github.com/dcjanus/userscripts
-// @version      20260707
+// @version      20260712
 // @description  useful tweaks for bilibili.com
 // @author       kookxiang, DCjanus
 // @match        https://*.bilibili.com/*
@@ -392,10 +392,6 @@ if (
 	location.href.startsWith("https://www.bilibili.com/video/") ||
 	location.href.startsWith("https://www.bilibili.com/bangumi/play/")
 ) {
-	const PLAYER_HORIZONTAL_WHEEL_SEEK_COOLDOWN_MS = 250;
-	const PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS = 5;
-	let lastPlayerHorizontalWheelSeekAt = 0;
-
 	function isEditableTarget(target) {
 		return (
 			typeof target?.closest === "function" &&
@@ -412,39 +408,6 @@ if (
 				return rect.width > 0 && rect.height > 0;
 			},
 		);
-	}
-
-	function isPlayerFullscreen() {
-		if (document.fullscreenElement) return true;
-		return !!document.querySelector(
-			[
-				".bpx-player-container[data-screen='full']",
-				".bpx-player-container[data-screen='fullscreen']",
-				".bpx-player-container.bpx-state-fullscreen",
-				".bpx-player-container.bpx-player-fullscreen",
-				"#bilibili-player.mode-fullscreen",
-			].join(","),
-		);
-	}
-
-	function findPlayerVideo() {
-		return (
-			document.fullscreenElement?.querySelector?.("video") ||
-			document.querySelector("#bilibili-player video") ||
-			document.querySelector(".bpx-player-container video") ||
-			document.querySelector("video")
-		);
-	}
-
-	function seekPlayerVideo(seconds) {
-		const video = findPlayerVideo();
-		if (!video || !Number.isFinite(video.duration)) return false;
-
-		video.currentTime = Math.min(
-			Math.max(video.currentTime + seconds, 0),
-			video.duration,
-		);
-		return true;
 	}
 
 	document.addEventListener(
@@ -471,33 +434,6 @@ if (
 			webFullscreenButton.click();
 		},
 		true,
-	);
-
-	document.addEventListener(
-		"wheel",
-		(e) => {
-			if (!isPlayerFullscreen()) return;
-			if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
-
-			e.preventDefault();
-			e.stopImmediatePropagation();
-
-			const now = Date.now();
-			if (
-				now - lastPlayerHorizontalWheelSeekAt <
-				PLAYER_HORIZONTAL_WHEEL_SEEK_COOLDOWN_MS
-			) {
-				return;
-			}
-			lastPlayerHorizontalWheelSeekAt = now;
-
-			seekPlayerVideo(
-				e.deltaX > 0
-					? PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS
-					: -PLAYER_HORIZONTAL_WHEEL_SEEK_SECONDS,
-			);
-		},
-		{ capture: true, passive: false },
 	);
 }
 


### PR DESCRIPTION
## Why

- 全屏横向滚轮调进度的实际使用价值较低，并可能干扰播放器原生滚轮行为。

## What

- 移除全屏状态下横向滚轮快进或快退 5 秒的功能。
- 删除对应的全屏检测、视频定位和滚轮冷却逻辑。
- 保留 `G` 键切换网页全屏的现有行为，并更新 userscript 版本。

## BREAKING CHANGE

- 影响范围：横向滚轮不再控制视频进度。
- 迁移方式：无需修改配置；滚轮事件将完全交由 B 站播放器处理。
